### PR TITLE
增加新条目的翻译

### DIFF
--- a/project/assets/thebetweenlands/lang/zh_cn.lang
+++ b/project/assets/thebetweenlands/lang/zh_cn.lang
@@ -878,6 +878,7 @@ chat.rope.too_far=你离最后一个引路绳的定位光点太远了。
 chat.bed_spawn_set=你的出生点被重设到你面前的苔藓床的位置了。
 
 chat.talisman.noplace=这里的空间不足以召唤传送门。
+chat.talisman.wrongdimension=不允许在这个维度召唤传送门。
 chat.talisman.linked=你手中的沼泽护身符现在链接到了这个传送门。
 chat.talisman.cant_link=这几个传送门不能被链接到一起。
 chat.talisman.too_far=这个传送门太远，不能链接。
@@ -1411,6 +1412,8 @@ config.thebetweenlands.portal_unsafe_biomes=不应传送到的群系黑名单
 config.thebetweenlands.portal_unsafe_biomes.tooltip=传送树会避免这些生物群系中生成。
 config.thebetweenlands.portal_biome_search_range=传送门群系搜索半径
 config.thebetweenlands.portal_biome_search_range.tooltip=生成一个传送门时，会在这一半径范围内搜寻合适的生物群系。如果你发现生成传送门时，不能总是搜索到合适的群系，可以调高这一数值，但需要更多的时间来生成传送门。
+config.thebetweenlands.generate_portal_in_end=在末地生成传送树
+config.thebetweenlands.generate_portal_in_end.tooltip=通过自定义传送树传送到末地后，是否在末地召唤返回传送树。
 
 config.thebetweenlands.rendering=渲染
 config.thebetweenlands.rendering.tooltip=关于游戏渲染和视觉效果的设置


### PR DESCRIPTION
发现 The Betweenlands 模组的英文语言文件新增了三个条目，及时翻译之。

- [ ] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [ ] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [ ] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
