### PR TITLE
完成packagedauto翻译，之前的翻译丢到old了

### DIFF
--- a/project/assets/packagedauto/lang/zh_cn.lang
+++ b/project/assets/packagedauto/lang/zh_cn.lang
@@ -1,16 +1,16 @@
 tile.packagedauto.packager.name=打包机
 tile.packagedauto.encoder.name=编码器
 tile.packagedauto.encoder.save=保存
-tile.packagedauto.encoder.pattern_slot=合成%s 
-tile.packagedauto.encoder.change_recipe_type=改变配方类型
+tile.packagedauto.encoder.pattern_slot=合成槽位 %s
+tile.packagedauto.encoder.change_recipe_type=改变合成类型
 tile.packagedauto.unpackager.name=解包机
 
 item.packagedauto.recipe_holder.name=样板包储存器
-item.packagedauto.recipe_holder.recipes=制作：
+item.packagedauto.recipe_holder.recipes=合成：
 item.packagedauto.package.name=样板包
 item.packagedauto.package.index=索引：%d
-item.packagedauto.package.items=使用：
+item.packagedauto.package.items=使用物品：
 item.packagedauto.package_component.name=打包组件
 
 recipe.packagedauto.processing=处理中
-recipe.packagedauto.processing.short=制作
+recipe.packagedauto.processing.short=处理中

--- a/project/assets/packagedauto/lang/zh_cn.lang
+++ b/project/assets/packagedauto/lang/zh_cn.lang
@@ -6,10 +6,10 @@ tile.packagedauto.encoder.change_recipe_type=改变配方类型
 tile.packagedauto.unpackager.name=解包机
 
 item.packagedauto.recipe_holder.name=样板包储存器
-item.packagedauto.recipe_holder.recipes=制作:
+item.packagedauto.recipe_holder.recipes=制作：
 item.packagedauto.package.name=样板包
-item.packagedauto.package.index=索引: %d
-item.packagedauto.package.items=使用:
+item.packagedauto.package.index=索引：%d
+item.packagedauto.package.items=使用：
 item.packagedauto.package_component.name=打包组件
 
 recipe.packagedauto.processing=处理中

--- a/project/assets/packagedauto/lang/zh_cn_old.lang
+++ b/project/assets/packagedauto/lang/zh_cn_old.lang
@@ -1,13 +1,1 @@
-tile.packagedauto.packager.name=打包机
 
-tile.packagedauto.encoder.name=编码器
-
-tile.packagedauto.encoder.save=保存
-
-tile.packagedauto.encoder.change_recipe_type=更改合成表类型
-
-item.packagedauto.recipe_holder.recipes=合成表：
-
-item.packagedauto.package.items=物品：
-
-recipe.packagedauto.processing=处理中

--- a/project/assets/packagedauto/lang/zh_cn_old.lang
+++ b/project/assets/packagedauto/lang/zh_cn_old.lang
@@ -1,0 +1,13 @@
+tile.packagedauto.packager.name=打包机
+
+tile.packagedauto.encoder.name=编码器
+
+tile.packagedauto.encoder.save=保存
+
+tile.packagedauto.encoder.change_recipe_type=更改合成表类型
+
+item.packagedauto.recipe_holder.recipes=合成表：
+
+item.packagedauto.package.items=物品：
+
+recipe.packagedauto.processing=处理中


### PR DESCRIPTION
- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
