### PR TITLE
Update zh_cn.properties

### DIFF
--- a/project/assets/ic2/lang_ic2/zh_cn.properties
+++ b/project/assets/ic2/lang_ic2/zh_cn.properties
@@ -41,7 +41,7 @@ misc_resource.iridium_ore=铱矿石
 misc_resource.iridium_shard=铱碎片
 misc_resource.matter=UU物质
 misc_resource.resin=粘性树脂
-misc_resource.slag=矿渣
+misc_resource.slag=炉渣
 misc_resource.iodine=碘
 misc_resource.water_sheet=水
 misc_resource.lava_sheet=熔岩
@@ -789,7 +789,7 @@ te.nuclear_reactor=核反应堆
 NuclearReactor.gui.name=核反应堆
 NuclearReactor.gui.info.EUoutput=输出：%1$s EU/t
 NuclearReactor.gui.info.HUoutput=输出：%1$s HU/s
-NuclearReactor.gui.info.temp=核心温度：%1$.2f%%
+NuclearReactor.gui.info.temp=堆温：%1$.2f%%
 NuclearReactor.gui.mode.fluid=核反应堆处于流体冷却模式：输出100%
 NuclearReactor.gui.mode.electric=核反应堆处于EU模式：输出50%
 


### PR DESCRIPTION
翻译成堆温（反应堆温度）更合适，因为工业2玩家，尤其是玩1.7.10的，已经习惯了这个名字。

- [x] 我已经检查文件路径正确，即 `project/assets/ic2/lang_ic2/zh_cn.properties`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
