### PR TITLE
修改了一个表述上的严重错误

### DIFF
--- a/project/assets/whoosh/lang/zh_cn.lang
+++ b/project/assets/whoosh/lang/zh_cn.lang
@@ -1,8 +1,8 @@
 chat.transporter.dimension.warning=不能跨维度传送。
-chat.transporter.fluid.warning=传送器流体不足。缺少 %s mb。
+chat.transporter.fluid.warning=谐振末影珍珠流体不足。缺少 %s mb。
 chat.transporter.rf.warning=传送器中 RF 能量不足。缺少%s RF。
 gui.whoosh.transporter=传送
-info.whoosh.transporter.a.0=眨眼
+info.whoosh.transporter.a.0=闪现
 info.whoosh.transporter.a.1=传送
 info.whoosh.transporter.b.0=§e按（%s）改变传送模式§r
 info.whoosh.transporter.c.0=§8无法跨维度传送。§r
@@ -16,5 +16,5 @@ item.whoosh.transporter.standard3.name=传送器（信素）
 item.whoosh.transporter.standard4.name=传送器（谐振）
 itemGroup.whoosh.creativeTab=Whoosh
 tab.whoosh.transporter.0=允许你传送到指定位置。
-tab.whoosh.transporter.1=跨维度传送回消耗流体。
+tab.whoosh.transporter.1=跨维度传送会消耗流体。
 tab.whoosh.transporter.2=如果你在时空连续体中丢失了肢体，我们不负责任。


### PR DESCRIPTION
- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)

这个mod里面传送器的"blink"模式是“向指定方向位移一段距离”。因此，“眨眼”这个翻译显然是错误的。改为“闪现”可能能够更好地表达含义。
除此之外，“流体不足”的提示原本并未指出是何种流体，表意不清。因此，将其提示更换为“谐振末影珍珠流体不足”，以向玩家指明需要使用什么流体。
除此之外，“跨维度传送回消耗流体”拼写有误，应为“跨维度传送会消耗流体”。