### PR TITLE
在爬虫名单中添加 Better Diving 和 Auraddons

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -118,6 +118,8 @@ mod_whitelist:
   - harder-farming
   - expanded-industry
   - millenaire # 千年村庄（Millénaire）
+  - better-diving
+  - auraddons
 
 # 爬虫爬取 modpack 白名单，在此名单上的 modpack 会被爬取
 # 仅适用于 curseforge 整合


### PR DESCRIPTION
- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
Better Diving 资源包中已有汉化，需加入爬虫名单
Auraddons 是自然灵气的拓展，鉴于自然灵气仅在资源包有汉化，其拓展也在资源包汉化更好