### PR TITLE
更新 MTS 官方附加包的翻译；移除了 MTS 官方附加包的部分翻译；加入 Immersive Vehicles（MTS）的翻译

### DIFF
--- a/project/assets/mts/lang/zh_cn.lang
+++ b/project/assets/mts/lang/zh_cn.lang
@@ -1,0 +1,208 @@
+death.attack.propellor.null.null=%1$s 被螺旋桨绞碎了
+death.attack.propellor.null.player=%1$s 在和 %2$s 战斗时被螺旋桨绞碎了
+death.attack.propellor.player.null=%1$s 被 %2$s 用螺旋桨绞碎了
+death.attack.propellor.player.player=%1$s 在和 %3$s 战斗时被 %2$s 用螺旋桨绞碎了
+
+death.attack.wheel.null.null=%1$s 被撞死了
+death.attack.wheel.null.player=%1$s 在和 %2$s 战斗时被撞死了
+death.attack.wheel.player.null=%1$s 被 %2$s 撞死了
+death.attack.wheel.player.player=%1$s 在和 %3$s 战斗时被 %2$s 撞死了
+
+death.attack.planecrash.null.null=%1$s 在空难中死亡
+death.attack.planecrash.null.player=%1$s 在和 %2$s 战斗时因为分心而坠机死亡
+death.attack.planecrash.player.null=%2$s 撞毁了他们的飞机并杀了 %1$s
+death.attack.planecrash.player.player=%1$s 在和 %2$s 战斗时因为分心而被 %3$s 开飞机撞死了
+
+death.attack.carcrash.null.null=%1$s 在车祸中死亡
+death.attack.carcrash.null.player=%1$s 在和 %2$s 战斗时因为分心而在车祸中死亡
+death.attack.carcrash.player.null=%2$s 撞毁了他们的车并杀了 %1$s
+death.attack.carcrash.player.player=%1$s 在和 %2$s 战斗时因为分心而被 %3$s 开车撞死了
+
+interact.key.info.lock=载具已锁定！
+interact.key.info.unlock=载具已解锁！
+interact.key.info.own=你现在是载具的主人！
+interact.key.info.unown=你不再是该载具的主人！
+interact.key.failure.notowner=只有该载具的主人可以做新的钥匙！
+interact.key.failure.wrongkey=不是此载具的钥匙！
+interact.key.failure.alreadyowned=你不是该载具的主人，所以你不能变更其所有权！
+
+interact.fuelpump.connect=已连接加油机并开始加油。
+interact.fuelpump.complete=载具的燃油已加满，正在断开连接。
+interact.fuelpump.empty=加油机是空的，正在断开连接。
+interact.fuelpump.disconnect=正在断开连接并停止加油。
+interact.fuelpump.toofar=加油机距离载具太远。加油机与载具的距离必须在 16 格方块内。
+
+interact.failure.seattaken=座位已被占用！
+interact.failure.vehiclelocked=载具已锁定！
+interact.failure.vehicleowned=你不能移除这个载具及它的零件，因为你不是载具的主人！
+
+input.aircraft.mod=功能键
+input.aircraft.camlock=锁定镜头
+input.aircraft.yaw=偏航
+input.aircraft.yaw_r=偏航（右）
+input.aircraft.yaw_l=偏航（左）
+input.aircraft.pitch=俯仰
+input.aircraft.pitch_u=俯仰（上）
+input.aircraft.pitch_d=俯仰（下）
+input.aircraft.roll=横滚
+input.aircraft.roll_r=横滚（右）
+input.aircraft.roll_l=横滚（左）
+input.aircraft.throttle=节流阀
+input.aircraft.throttle_u=节流阀（加大）
+input.aircraft.throttle_d=节流阀（减小）
+input.aircraft.flaps_u=襟翼（收回）
+input.aircraft.flaps_d=襟翼（放出）
+input.aircraft.brake=制动
+input.aircraft.panel=面板
+input.aircraft.park=手刹
+input.aircraft.gun=射击
+input.aircraft.zoom_i=镜头（拉近）
+input.aircraft.zoom_o=镜头（拉远）
+input.aircraft.changehud=更改 HUD 模式
+input.aircraft.trim_yaw_r=偏航配平（右）
+input.aircraft.trim_yaw_l=偏航配平（左）
+input.aircraft.trim_pitch_u=俯仰配平（上）
+input.aircraft.trim_pitch_d=俯仰配平（下）
+input.aircraft.trim_roll_r=横滚配平（右）
+input.aircraft.trim_roll_l=横滚配平（左）
+input.aircraft.reverse=反推力装置
+
+input.car.mod=功能键
+input.car.camlock=锁定镜头
+input.car.turn=转向
+input.car.turn_r=右转
+input.car.turn_l=左转
+input.car.gas=油门
+input.car.brake=制动
+input.car.shift_u=升档
+input.car.shift_d=降档
+input.car.start=点火
+input.car.horn=鸣笛
+input.car.siren=警报
+input.car.lights=灯光
+input.car.lights_special=特殊灯光
+input.car.park=手刹
+input.car.gun=射击
+input.car.zoom_i=镜头（拉近）
+input.car.zoom_o=镜头（拉远）
+input.car.changehud=更改 HUD 模式
+input.car.stop=熄火
+input.car.turnsignal_r=转向灯（右）
+input.car.turnsignal_l=转向灯（左）
+
+gui.trafficsignalcontroller.scan=扫描信号部件
+gui.trafficsignalcontroller.scandistance=扫描距离：
+gui.trafficsignalcontroller.scanfound=扫描结果：
+gui.trafficsignalcontroller.primary=主轴：
+gui.trafficsignalcontroller.signalmode=模式：
+gui.trafficsignalcontroller.modetime=定时
+gui.trafficsignalcontroller.modetrigger=感应车流
+gui.trafficsignalcontroller.greenmaintime=主轴上的信号为绿灯的时长：
+gui.trafficsignalcontroller.greencrosstime=交叉轴上的信号为绿灯的时长：
+gui.trafficsignalcontroller.yellowtime=信号为黄灯的时长：
+gui.trafficsignalcontroller.allredtime=信号同时为红灯的时长：
+gui.trafficsignalcontroller.confirm=确认
+
+gui.vehicle_bench.type=类型
+gui.vehicle_bench.weight=重量（千克）
+gui.vehicle_bench.fuel=燃料容量 (mb)
+gui.vehicle_bench.controllers=驾驶员/飞行员
+gui.vehicle_bench.passengers=乘客
+gui.vehicle_bench.cargo=货物
+gui.vehicle_bench.engine=发动机尺寸
+gui.vehicle_bench.wheel=轮子尺寸
+
+gui.panel.navigationlights=航行灯
+gui.panel.strobelights=防撞灯
+gui.panel.taxilights=滑行灯
+gui.panel.landinglights=着陆灯
+gui.panel.magneto=磁电机
+gui.panel.starter=启动
+gui.panel.trim_roll=横滚配平
+gui.panel.trim_pitch=俯仰配平
+gui.panel.trim_yaw=偏航配平
+gui.panel.reverse=反推力装置
+
+gui.instruments.main=主仪表
+gui.instruments.control=控制面板
+gui.instruments.clear=移除
+gui.instruments.idle=选择一个仪表位。
+gui.instruments.decide=点击一个仪表进行添加，或点击“移除”来移除原有的仪表。
+
+gui.config.header.config=配置
+gui.config.header.controls=控制
+gui.config.controls.title=选择一个要改变的配置：
+gui.config.controls.aircraft.keyboard=飞机（键盘）
+gui.config.controls.aircraft.joystick=飞机（手柄）
+gui.config.controls.car.keyboard=汽车（键盘）
+gui.config.controls.car.joystick=汽车（手柄）
+gui.config.controls.confirm=确认
+gui.config.joystick.select=选择手柄：
+gui.config.joystick.name=名称：
+gui.config.joystick.type=类型：
+gui.config.joystick.state=状态：
+gui.config.joystick.assignment=分配为：
+gui.config.joystick.cancel=取消
+gui.config.joystick.clear=清除分配
+gui.config.joystick.choosemap=选择这个按钮分配到的功能。
+gui.config.joystick.selectdigital=这个按钮（数字）可以控制：
+gui.config.joystick.selectanalog=这个按钮（模拟）可以控制：
+gui.config.joystick.normal=一般
+gui.config.joystick.invert=反向
+gui.config.joystick.confirm=确认
+
+info.item.engine.automatic=变速箱：自动
+info.item.engine.manual=变速箱：手动
+info.item.engine.gearratios=齿轮比：
+info.item.engine.bypassratio=涵道比：
+info.item.engine.maxrpm=最大可能的每分钟转数：
+info.item.engine.maxsaferpm=最大安全的每分钟转数：
+info.item.engine.fuelconsumption=燃料用量 (mb/t)：
+info.item.engine.creative=创造模式：无需燃料
+info.item.ground_device.diameter=攀爬高度：
+info.item.ground_device.rotatesonshaft_true=是轮子 
+info.item.ground_device.rotatesonshaft_false=非轮子
+info.item.ground_device.canfloat_true=可漂浮
+info.item.ground_device.canfloat_false=不可漂浮
+info.item.propeller.staticPitch=固定螺距
+info.item.propeller.dynamicPitch=可变螺距
+info.item.propeller.numberBlades=叶片数量：
+info.item.propeller.pitch=螺距：
+info.item.propeller.diameter=直径：
+info.item.propeller.maxrpm=最大每分钟转数：
+info.item.propeller.health=生命值（耐久度）：
+
+info.item.wrench.use=右键点击载具以更换该载具的仪表。
+info.item.wrench.attack=左键点击载具部件以卸下该部件。
+info.item.wrench.sneakattack=潜行并左键点击载具以移除该载具。
+info.item.key.line1=右键点击载具以锁定载具。
+info.item.key.line2=锁定的载具只能使用钥匙解锁。
+info.item.key.line3=潜行并右键点击载具以取得所有权。
+info.item.key.line4=再次潜行并右键点击载具以放弃所有权。
+info.item.key.line5=已取得所有权的载具只能被你或管理员摧毁。
+
+item.wrench.name=扳手
+item.key.name=钥匙
+item.manual.name=MTS 说明书
+
+item.propellerbench.name=螺旋桨工作台
+item.wheelbench.name=轮子工作台
+item.seatbench.name=台锯
+item.custombench.name=工具台
+item.instrumentbench.name=仪表工作台
+item.gunbench.name=机枪工作台
+
+item.fuelpump.name=加油机
+item.fuelpump.level=剩量：
+item.fuelpump.dispensed=已加：
+
+item.trafficsignalcontroller.name=交通信号控制器
+
+tile.pole.name=柱子
+tile.polebase.name=柱子底座
+tile.trafficsignal.name=交通信号灯
+tile.streetlight.name=路灯
+tile.trafficsign.name=交通标志牌
+
+itemGroup.tabMTSCore=MTS 核心组件
+key.config=打开按键配置界面

--- a/project/assets/mtsofficialpack/lang/zh_cn.lang
+++ b/project/assets/mtsofficialpack/lang/zh_cn.lang
@@ -1,5 +1,3 @@
-#由 Frost-ZX 翻译（模组版本：9.0.0）
-
 itemGroup.mtsofficialpack=MTS 官方载具附加包
 
 item.mtsofficialpack.mc172_oak.name=橡木 MC-172（飞机）
@@ -9,50 +7,26 @@ item.mtsofficialpack.mc172_jungle.name=丛林木 MC-172（飞机）
 item.mtsofficialpack.mc172_acacia.name=金合欢木 MC-172（飞机）
 item.mtsofficialpack.mc172_darkoak.name=深色橡木 MC-172（飞机）
 
-item.mtsofficialpack.pzlp11.name=PZL P11.c（战斗机）
-
-item.mtsofficialpack.vulcanair_white.name=白色 Vulcanair（飞机）
-item.mtsofficialpack.vulcanair_green.name=绿色 Vulcanair（飞机）
-item.mtsofficialpack.vulcanair_blue.name=蓝色 Vulcanair（飞机）
-item.mtsofficialpack.vulcanair_black.name=黑色 Vulcanair（飞机）
-item.mtsofficialpack.vulcanair_red.name=红色 Vulcanair（飞机）
-item.mtsofficialpack.vulcanair_dark_red.name=深红色 Vulcanair（飞机）
-item.mtsofficialpack.vulcanair_white_orange.name=橙白色 Vulcanair（飞机）
-
-item.mtsofficialpack.comanche_blue.name=蓝色卡曼奇（飞机）
-item.mtsofficialpack.comanche_grey.name=灰色卡曼奇（飞机）
-item.mtsofficialpack.comanche_red.name=红色卡曼奇（飞机）
-item.mtsofficialpack.comanche_yellow.name=黄色卡曼奇（飞机）
-
-item.mtsofficialpack.e500_blue.name=蓝色 Eclipse 500（飞机）
-item.mtsofficialpack.e500_green.name=绿色 Eclipse 500（飞机）
-item.mtsofficialpack.e500_red.name=红色 Eclipse 500（飞机）
-item.mtsofficialpack.e500_yellow.name=黄色 Eclipse 500（飞机）
-
-item.mtsofficialpack.gmcbrig_black.name=黑色 GMC Brigadier（卡车）
-item.mtsofficialpack.gmcbrig_blue.name=蓝色 GMC Brigadier（卡车）
-item.mtsofficialpack.gmcbrig_green.name=绿色 GMC Brigadier（卡车）
-item.mtsofficialpack.gmcbrig_red.name=红色 GMC Brigadier（卡车）
-item.mtsofficialpack.gmcbrig_white.name=白色 GMC Brigadier（卡车）
-item.mtsofficialpack.gmcbrig_yellow.name=黄色 GMC Brigadier（卡车）
-
 item.mtsofficialpack.firetruck.name=消防车
 
 item.mtsofficialpack.crate.name=载具装货箱
+item.mtsofficialpack.barrel.name=液体运输桶
+item.mtsofficialpack.bullet762.name=7.62mm 枪弹
 item.mtsofficialpack.engineamci4.name=AMC I4 汽车发动机
-item.mtsofficialpack.enginebristolmercury.name=Bristol Mercury 飞机发动机
+item.mtsofficialpack.enginebristolmercury.name=Bristol Mercury 飞机引擎
 item.mtsofficialpack.enginedetroitdiesel.name=底特律柴油卡车发动机
-item.mtsofficialpack.enginelycomingo360.name=Lycoming O-360 飞机发动机
+item.mtsofficialpack.enginelycomingo360.name=Lycoming O-360 飞机引擎
 item.mtsofficialpack.enginepw610f.name=Pratt & Whitney 610F 喷气发动机
+item.mtsofficialpack.pontoon.name=浮筒
 item.mtsofficialpack.propellersmall2blade.name=小型双叶螺旋桨
-item.mtsofficialpack.propellersmall3blade.name=小型三叶螺旋桨（动态螺距）
+item.mtsofficialpack.propellersmall3blade.name=小型三叶螺旋桨（可变螺距）
 item.mtsofficialpack.propellerlarge2blade.name=大型双叶螺旋桨
-item.mtsofficialpack.seatblue.name=蓝色座位
-item.mtsofficialpack.seatbrown.name=棕色座位
-item.mtsofficialpack.seatgrey.name=灰色座位
-item.mtsofficialpack.seatpink.name=粉红色座位
-item.mtsofficialpack.seatred.name=红色座位
-item.mtsofficialpack.seatwhite.name=白色座位
+item.mtsofficialpack.seatblue.name=蓝色座椅
+item.mtsofficialpack.seatbrown.name=棕色座椅
+item.mtsofficialpack.seatgrey.name=灰色座椅
+item.mtsofficialpack.seatpink.name=粉红色座椅
+item.mtsofficialpack.seatred.name=红色座椅
+item.mtsofficialpack.seatwhite.name=白色座椅
 item.mtsofficialpack.skid.name=起落架
 item.mtsofficialpack.wheelsmall.name=小型轮子
 item.mtsofficialpack.wheelmedium.name=中型轮子


### PR DESCRIPTION
- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
