### PR TITLE
更新交错次元模组的语言文件

### DIFF
--- a/project/assets/thebetweenlands/lang/zh_cn.lang
+++ b/project/assets/thebetweenlands/lang/zh_cn.lang
@@ -1,3 +1,5 @@
+# Blocks
+
 tile.thebetweenlands.angry_betweenstone.name=愤怒的交错石
 tile.thebetweenlands.aqua_middle_gem_ore.name=水蓝元素宝石矿石
 tile.thebetweenlands.arrow_arum.name=茯苓
@@ -221,6 +223,8 @@ tile.thebetweenlands.sulfur_furnace.name=硫磺熔炉
 tile.thebetweenlands.sulfur_furnace_dual.name=双层硫磺熔炉
 tile.thebetweenlands.fallen_leaves.name=落叶
 tile.thebetweenlands.spike_trap.name=尖刺陷阱
+tile.thebetweenlands.mud_brick_spike_trap.name=泥砖尖刺陷阱
+tile.thebetweenlands.mud_tiles_spike_trap.name=泥地砖尖刺陷阱
 tile.thebetweenlands.possessed_block.name=鬼魂附着的方块
 tile.thebetweenlands.energy_barrier.name=能量屏障
 tile.thebetweenlands.coarse_swamp_dirt.name=粗糙的沼泽土
@@ -363,6 +367,80 @@ tile.thebetweenlands.scabyst_brick_slab.name=痂壳晶砖台阶
 tile.thebetweenlands.scabyst_pitstone_dotted.name=痂壳晶斑点麻纹石
 tile.thebetweenlands.scabyst_pitstone_horizontal.name=痂壳晶条纹麻纹石
 tile.thebetweenlands.waystone.name=巨石柱
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_vertical.name=垂直的蠕虫柱
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_vertical_decay_1.name=垂直的蠕虫柱(等级 1)
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_vertical_decay_2.name=垂直的蠕虫柱(等级 2)
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_vertical_decay_3.name=垂直的蠕虫柱(等级 3)
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_vertical_decay_4.name=垂直的蠕虫柱(等级 4)
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_vertical_decay_full.name=垂直的蠕虫柱(等级 5)
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_top.name=蠕虫柱顶
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_top_decay_1.name=蠕虫柱顶(等级 1)
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_top_decay_2.name=蠕虫柱顶(等级 2)
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_top_decay_3.name=蠕虫柱顶(等级 3)
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_top_decay_4.name=蠕虫柱顶(等级 4)
+tile.thebetweenlands.worm_dungeon_pillar.worm_pillar_top_decay_full.name=蠕虫柱顶(等级 5)
+tile.thebetweenlands.dripping_mud.name=滴落的泥巴
+tile.thebetweenlands.mud_tiles.mud_tiles.name=泥地砖
+tile.thebetweenlands.mud_tiles.mud_tiles_decay.name=腐朽的泥地砖
+tile.thebetweenlands.mud_tiles.mud_tiles_cracked.name=裂纹泥地砖
+tile.thebetweenlands.mud_tiles.mud_tiles_cracked_decay.name=腐朽的裂纹泥地砖
+tile.thebetweenlands.puffshroom.name=喷射蘑菇
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_carved.name=雕刻的泥砖
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_carved_decay_1.name=雕刻的泥砖(等级 1)
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_carved_decay_2.name=雕刻的泥砖(等级 2)
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_carved_decay_3.name=雕刻的泥砖(等级 3)
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_carved_decay_4.name=雕刻的泥砖(等级 4)
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_carved_edge.name=雕刻的泥砖边缘
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_carved_edge_decay_1.name=雕刻的泥砖边缘(等级 1)
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_carved_edge_decay_2.name=雕刻的泥砖边缘(等级 2)
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_carved_edge_decay_3.name=雕刻的泥砖边缘(等级 3)
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_carved_edge_decay_4.name=雕刻的泥砖边缘(等级 4)
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_decay_1.name=泥砖(等级 1)
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_decay_2.name=泥砖(等级 2)
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_decay_3.name=泥砖(等级 3)
+tile.thebetweenlands.mud_bricks_carved.mud_bricks_decay_4.name=泥砖(等级 4)
+tile.thebetweenlands.mud_brick_stairs_decay_1.name=泥砖楼梯(等级 1)
+tile.thebetweenlands.mud_brick_stairs_decay_2.name=泥砖楼梯(等级 2)
+tile.thebetweenlands.mud_brick_stairs_decay_3.name=泥砖楼梯(等级 3)
+tile.thebetweenlands.mud_brick_stairs_decay_4.name=泥砖楼梯(等级 4)
+tile.thebetweenlands.mud_brick_slab_decay_1.name=泥砖台阶(等级 1)
+tile.thebetweenlands.mud_brick_slab_decay_2.name=泥砖台阶(等级 2)
+tile.thebetweenlands.mud_brick_slab_decay_3.name=泥砖台阶(等级 3)
+tile.thebetweenlands.mud_brick_slab_decay_4.name=泥砖台阶(等级 4)
+tile.thebetweenlands.edge_shroom.name=边缘蘑菇
+tile.thebetweenlands.mud_tower_beam_origin.name=光源
+tile.thebetweenlands.mud_tower_beam_relay.name=光束透镜
+tile.thebetweenlands.mud_tower_beam_tube.name=光束通道
+tile.thebetweenlands.mud_tower_beam_lens_supports.name=透镜支架
+tile.thebetweenlands.loot_urn.1.name=战利品罐
+tile.thebetweenlands.loot_urn.2.name=战利品罐
+tile.thebetweenlands.loot_urn.3.name=战利品罐
+tile.thebetweenlands.mud_tiles_water.name=破裂的泥地砖
+tile.thebetweenlands.dungeon_wall_candle.name=壁挂蜡烛
+tile.thebetweenlands.wooden_support_beam_rotten_1.name=腐烂的支柱
+tile.thebetweenlands.wooden_support_beam_rotten_2.name=腐烂的支柱
+tile.thebetweenlands.wooden_support_beam_rotten_3.name=腐烂的支柱
+tile.thebetweenlands.log_rotten_bark_carved_1.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_2.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_3.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_4.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_5.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_6.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_7.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_8.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_9.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_10.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_11.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_12.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_13.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_14.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_15.name=雕刻的烂树皮
+tile.thebetweenlands.log_rotten_bark_carved_16.name=雕刻的烂树皮
+tile.thebetweenlands.mud_tower_brazier.name=火盆
+tile.thebetweenlands.dungeon_door_runes.name=地牢门
+tile.thebetweenlands.dungeon_door_runes_mimic.name=地牢门模仿者
+tile.thebetweenlands.dungeon_door_combination.name=地牢门密码
+
 # Items
 
 item.thebetweenlands.enum.unknown.name=出错的物品
@@ -572,6 +650,7 @@ item.thebetweenlands.tar_beast_heart.name=焦油怪的心脏
 item.thebetweenlands.tar_beast_heart_animated.name=跳动的焦油怪心脏
 item.thebetweenlands.tar_drip.name=焦油滴
 item.thebetweenlands.test_item.name=测试物品
+item.thebetweenlands.test_item_chimp.name=测试香蕉
 item.thebetweenlands.location_debug.name=位置调试工具
 item.thebetweenlands.the_explorer.name=探险家唱片
 item.thebetweenlands.thorns_item.name=荆条
@@ -701,6 +780,7 @@ item.thebetweenlands.bone_wayfinder.name=寻路之骨
 item.thebetweenlands.magic_item_magnet.name=魔法物品磁铁
 item.thebetweenlands.gem_singer.name=宝石颂唱者
 item.thebetweenlands.bark_amulet.name=树皮护身符
+
 # Herblore
 item.thebetweenlands.elixir.dentrothyst_vial.green.name=绿色木晶药瓶
 item.thebetweenlands.elixir.dentrothyst_vial.orange.name=橙色木晶药瓶
@@ -709,11 +789,13 @@ item.thebetweenlands.aspect_vial.green.name=绿色木晶要素瓶
 item.thebetweenlands.aspect_vial.orange.name=橙色木晶要素瓶
 item.thebetweenlands.aspect_vial.green.filled.name=%s (%s)
 item.thebetweenlands.aspect_vial.orange.filled.name=%s (%s)
+
 # Fluids
 fluid.swamp_water=沼泽水
 fluid.tar=焦油
 fluid.stagnant_water=死水
 fluid.rubber=橡胶液
+
 # Creative Tabs
 itemGroup.thebetweenlands.block=交错次元 - 方块
 itemGroup.thebetweenlands.item=交错次元 - 物品
@@ -721,11 +803,15 @@ itemGroup.thebetweenlands.gear=交错次元 - 工具
 itemGroup.thebetweenlands.special=交错次元 - 特殊物品
 itemGroup.thebetweenlands.plants=交错次元 - 植物
 itemGroup.thebetweenlands.herblore=交错次元 - 药学
+
+
 # Container
 container.furnace_bl=硫磺熔炉
 container.dual_furnace_bl=双层硫磺熔炉
 container.lurker_skin_pouch=鳄皮物品袋
 container.lurker_skin_pouch.naming.save=保存
+
+
 # Locations
 location.wilderness.name=80:<scale:1.75>荒野</scale>
 location.caverns.name=80:<scale:1.75>洞穴</scale>
@@ -740,6 +826,7 @@ location.wight_tower_boss.name=80:原始恶意
 location.abandoned_shack.name=<scale:1.75>废墟</scale>
 location.underground_ruins.name=80:地下遗迹
 location.spirit_tree.name=80:灵魂树
+
 # Tooltips
 tooltip.arrow.octine=小心走火！
 tooltip.arrow.basilisk=能使人瘫痪的毒箭
@@ -767,9 +854,9 @@ tooltip.ring.flight=使用扇形菜单 \n 来装备它 [按下 '%s' ]， \n按 '
 tooltip.ring.power=使用扇形菜单 \n 来装备它 [按下 '%s']
 tooltip.ring.recruitment=使用扇形菜单 \n 来装备它 [按下 '%s']， \n 鼠标指向怪物并按住 '%s' \n 来暂时控制它们。
 tooltip.press.shift=按 'Shift' 查看详细信息
-tooltip.life_crystal.remaining=剩余 %d
+tooltip.life_crystal.remaining=剩余 %d 
 tooltip.shockwave_sword.usage=对地面右键 \n 来发出冲击波
-tooltip.shockwave_sword.broken=这柄冲击波剑损坏了 \n 需要在活化器中进行修理 \n
+tooltip.shockwave_sword.broken=这柄冲击波剑损坏了 \n 需要在活化器中进行修理 \n 
 tooltip.compost.compostable=可以用于堆肥
 tooltip.food_sickness.state.fine=尝起来不错
 tooltip.food_sickness.state.half=尝起来一般
@@ -793,7 +880,7 @@ tooltip.amulet.none=\n没有效果。\n试试镶嵌一个元素宝石。
 tooltip.amulet.aqua=\n佩戴时:\n §9- 有几率使被攻击的敌人虚弱\n §9- 且被攻击时有几率提升防御力
 tooltip.amulet.crimson=\n佩戴时:\n §9- 有几率提升攻击力\n §9- 且有几率伤害攻击你的敌人
 tooltip.amulet.green=\n佩戴时:\n §9- 有几率在攻击时恢复生命\n §9- 且有几率在被攻击时吸收伤害
-tooltip.amulet.usage=使用扇形菜单 \n来装备它 [按下 '%s' ] \n或按下 '%s'
+tooltip.amulet.usage=使用扇形菜单 \n来装备它 [按下 '%s' ] \n或按下 '%s' 
 tooltip.weedwood_bucket=手持它右键一棵橡胶树\n即可用它收集橡胶。
 tooltip.syrmorite_bucket=手持它右键一棵橡胶树\n即可用它收集橡胶。
 tooltip.bl_bucket=手持它右键一棵橡胶树\n即可用它收集橡胶。
@@ -811,6 +898,7 @@ tooltip.infusion.empty=空
 tooltip.bone_wayfinder=必须与巨石柱链接才能使用。
 tooltip.bone_wayfinder_linked=需要充足的经验值才能使用。\n链接到此处的巨石柱：\nX: %s\nY: %s\nZ: %s
 tooltip.lurker_skin_shield=可以当做船使用！
+
 tooltip.bl.elixir.potency=§9效果: %s
 tooltip.bl.elixir.duration=§9时长: %s (%s)
 tooltip.bl.elixir.when_applied=§5生效时:
@@ -842,6 +930,7 @@ tooltip.bl.elixir.healing.effect=加速身体恢复的能力，\n伤口不断得
 tooltip.bl.elixir.nimblefeet.effect=增强腿脚的肌肉，\n使你行动更敏捷
 tooltip.bl.elixir.weakness.effect=弱化持剑的手腕，\n降低攻击的伤害
 tooltip.bl.elixir.strength.effect=增强身体的力量，\n提高攻击的伤害
+
 # Chat
 chat.foodSickness.fine.0=啊，新鲜的食物！
 chat.foodSickness.fine.1=还行吧，总算是不一样的东西。
@@ -890,6 +979,7 @@ chat.foodSickness.sick.11=吃这个太累了，我要休息一下
 chat.foodSickness.sick.12=不了，我吃点别的换换口味。
 chat.foodSickness.sick.13=这玩意闻起来比看上去还要糟糕；我要找点别的来吃。
 chat.foodSickness.sick.15=这附近一定有别的食物，求你让我去找一下
+
 chat.aspect.discovery.book.none=你需要一本药学手册来记录你的发现。
 chat.aspect.discovery.gecko.none=你需要一只壁虎作为实验动物。
 chat.aspect.discovery.gecko.recovering=实验过后壁虎需要休息一会，你不能折磨实验动物。
@@ -911,32 +1001,47 @@ chat.aspect.discovery.armaniis=壁虎显得非常镇静，除了用可爱的小�
 chat.aspect.discovery.geoliirgaz=壁虎陷入了呆滞状态。似乎是受了Geoliirgaz要素的影响。
 chat.aspect.discovery.yihinren=你的壁虎非常膨胀。似乎是受了Yihinren要素的影响。
 chat.aspect.discovery.byariis=壁虎像着了魔一样四处看和咬自己的尾巴。似乎是受了Byariis要素的影响。
+
 chat.compost.full=堆肥箱已经满了。
 chat.compost.not.compostable=这个物品不能用于堆肥。
+
 chat.rope.already_connected=已经于另一根引路绳连接了。
 chat.rope.disconnected=你和引路绳脱离连接了。
 chat.rope.too_far=你离最后一个引路绳的定位光点太远了。
+
 chat.bed_spawn_set=你的出生点被重设到你面前的苔藓床的位置了。
+
 chat.talisman.noplace=这里的空间不足以召唤传送门。
 chat.talisman.wrongdimension=不允许在这个维度召唤传送门。
 chat.talisman.linked=你手中的沼泽护身符现在链接到了这个传送门。
 chat.talisman.cant_link=这几个传送门不能被链接到一起。
 chat.talisman.too_far=这个传送门太远，不能链接。
 chat.talisman.portal_linked=这些传送门已经链接起来了。
+
 chat.item.forbiddenfig=诅咒将降临吃下禁果的人！
+
 chat.flintandsteel=这里太潮湿了，用 %s 来点火很困难。
 chat.fertilizer=这个肥料 - %s ，在这个地方似乎不管用。
+
 chat.amulet.slot.added=你可以再佩戴一个护符了。
 chat.amulet.slot.full=你不能佩戴更多的护符了。
+
 chat.event.spook=你感到空气在战栗... 鬼魂的节日来了！
 chat.event.winter=雪橇和铃铛的声音从远处飘来...
+
 chat.repeller.shimmerstone_missing=这个驱魔器还需要一块闪光石才能使用。
 chat.amate_map.invalid=你不能在交错次元之外制作树皮地图。
+
 chat.equipment.equipped=穿上了 %s
 chat.equipment.unequipped=卸下了 %s
+
 chat.waystone.obstructed=你与巨石柱的链接被阻断了。
+
+chat.dungeon_door_runes.locked=地牢门密码已设置！
+
 # Damage Source
-death.attack.suffocation=沼泽之息将 %s 窒息至死
+death.attack.suffocation=沼泽之息将 %s 窒息至死 
+
 # Elixirs
 bl.elixir.petrify=麻痹药水
 bl.elixir.strength=力量增强之酿
@@ -973,6 +1078,7 @@ bl.elixir.foggedMind=意识混沌之药
 bl.elixir.deformed=形体无序之药
 bl.elixir.limbless=四肢截断之药
 bl.elixir.isolatedSenses=感官隔绝之药
+
 bl.elixir.potency.1=I
 bl.elixir.potency.2=II
 bl.elixir.potency.3=III
@@ -982,6 +1088,7 @@ bl.elixir.potency.6=VI
 bl.elixir.potency.7=VII
 bl.elixir.potency.8=VIII
 bl.elixir.potency.n=%s
+
 bl.elixir.duration.1=I
 bl.elixir.duration.2=II
 bl.elixir.duration.3=III
@@ -991,7 +1098,9 @@ bl.elixir.duration.6=VI
 bl.elixir.duration.7=VII
 bl.elixir.duration.8=VIII
 bl.elixir.duration.n=%s
+
 bl.potion.rootBound=根须缠绕
+
 # Entities
 entity.thebetweenlands.dark_druid.name=黑暗德鲁伊
 entity.thebetweenlands.angler.name=鮟鱇鱼
@@ -1050,10 +1159,13 @@ entity.thebetweenlands.spirit_tree_face_mask.name=灵树面罩
 entity.thebetweenlands.root_sprite.name=根须精灵
 entity.thebetweenlands.greebling.name=地精矮人
 entity.thebetweenlands.lurker_skin_raft.name=鳄皮筏子
+
 # Equipment
 equipment.menu.equip=佩戴%s
 equipment.menu.unequip=取下%s
 equipment.menu.page=第 %d 页
+
+
 # Music Discs
 item.thebetweenlands.record.astatos.desc=Voog2 - Astatos
 item.thebetweenlands.record.between_you_and_me.desc=Voog2 - Between You And Me
@@ -1069,11 +1181,15 @@ item.thebetweenlands.record.stuck_in_the_mud.desc=Voog2 - Stuck In The Mud
 item.thebetweenlands.record.waterlogged.desc=Voog2 - Waterlogged
 item.thebetweenlands.record.wandering_wisps.desc=Voog2 - Wandering Wisps
 item.thebetweenlands.record.ancient.desc=Voog2 - Ancient
+
+
 # Signs
 sign.fortress.line1=唯有那
 sign.fortress.line2=手持神剑的勇者
 sign.fortress.line3=才能够通过
 sign.fortress.line4=这个地方
+
+
 # JEI
 jei.thebetweenlands.animator.entity_spawn=这个配方会生成一只 %s
 jei.thebetweenlands.recipe.animator=活化器
@@ -1087,18 +1203,22 @@ jei.thebetweenlands.time.minutes=需用时 %d 分钟
 jei.thebetweenlands.time.seconds=需用时 %d 秒
 jei.thebetweenlands.animator.life=消耗生命水晶耐久数： %d
 jei.thebetweenlands.animator.fuel=消耗燃料数: %d
+
 # Commands
 command.generic.noplayer=只有玩家可以使用命令。
-command.blevent.success.on='%s' 天气事件开始。
-command.blevent.success.off='%s' 天气事件结束。
+
+command.blevent.success.on= '%s' 天气事件开始。
+command.blevent.success.off= '%s' 天气事件结束。
 command.blevent.success.alloff=所有天气事件已全部结束。
 command.blevent.success.enable=天气事件已启用。
 command.blevent.success.disable=天气事件已禁用。
+
 command.blevent.usage=/blevent <toggle|on|off|list|enable|disable>
 command.blevent.usage.toggle=/blevent toggle <天气事件名称>
 command.blevent.usage.on=/blevent on <天气事件名称>
 command.blevent.usage.off=/blevent off <天气事件名称>
-command.blevent.failure.unknown='%s'是未知的天气事件。
+
+command.blevent.failure.unknown= '%s'是未知的天气事件。
 command.blevent.failure.wrongdimension=你必须在交错次元世界内，才能使用交错次元的天气事件指令。
 command.blevent.failure.alreadyon=天气事件 '%s' 正在进行了。
 command.blevent.failure.alreadyoff=天气事件 '%s' 已经关闭了。
@@ -1106,6 +1226,7 @@ command.blevent.failure.alreadyenabled=天气事件已经被启用了。
 command.blevent.failure.alreadydisabled=天气事件已经被禁用了。
 command.blevent.failure.on=无法使天气事件 '%s' 开始。
 command.blevent.failure.off=无法使天气事件 '%s' 结束。
+
 command.aspectdiscovery.usage=指令格式: /aspectDiscovery <玩家> <reset|discover> <held|all>
 command.aspectdiscovery.book.none=没有药学手册可供书写。
 command.aspectdiscovery.held.null=你必须拿着一个物品。
@@ -1113,15 +1234,19 @@ command.aspectdiscovery.discover.held=结果: %s 要素: %d
 command.aspectdiscovery.discover.all=发现所有物品的所有要素。
 command.aspectdiscovery.reset.held=清除所有已经发现的要素。
 command.aspectdiscovery.reset.all=清除所有物品的已发现要素。
+
 command.aspect.reset.usage=指令格式: /resetAspects
 command.aspect.reset.confirm=输入 '/resetAspects confirm'以确认。
 command.aspect.reset.success=重设要素完成。
+
 command.blreloadrecipes.usage=指令格式: /blReloadRecipes
 command.blreloadrecipes.success=重新载入自定义配方。
 command.blreloadrecipes.failed=载入自定义配方失败。
+
 command.set_decay.usage=指令格式: /setDecay <玩家> <待扣减的残蚀值数> [残蚀值饱和度]
 command.decay.noint=残蚀值必须是个整数。
 command.decay_saturation.noint=残蚀值的饱和度必须是个整数。
+
 # Keybinds
 key.categories.betweenlands=交错次元
 key.open_pouch=打开鳄皮物品袋
@@ -1130,6 +1255,7 @@ key.return_scout=使侦查员返回(尚未使用)
 key.send_scout=派出侦查员(尚未使用)
 key.use_ring=使用戒指效果
 key.connect_caving_rope=连接/切断洞穴引路绳
+
 #Manual
 manual.aspect.found.in=此要素被发现于:
 manual.aspect.used.in=此要素被用于:
@@ -1137,6 +1263,7 @@ manual.has.aspects=该物品含有以下要素:
 manual.aspect_info.title=要素列表
 manual.ingredient_info.title=材料列表
 manual.open_entry=打开指南书
+
 manual.desire=欲望
 manual.corruption=腐化
 manual.muscle=肌肉
@@ -1151,6 +1278,8 @@ manual.enhance=强化
 manual.health=生命
 manual.form=形态
 manual.wind=风元素
+
+
 manual.azuwynn.description=这种要素作用于肌肉。<nl>一阶要素。
 manual.armaniis.description=这种要素影响一种<nl>存在或意识的渴望。<nl>二阶要素。
 manual.byariis.description=这种要素反转<nl>一切事物的自然属性。<nl>一阶要素。
@@ -1165,6 +1294,7 @@ manual.ordaniis.description=这种要素强化其他要素<nl>和任何形式的
 manual.yeowynn.description=这种要素影响身体<nl>恢复健康的能力。<nl>一阶要素。
 manual.yunugaz.description=这种要素与风元素有关。<nl>二阶要素。
 manual.yihinren.description=这种要素影响身体<nl>和精神的结构形式。<nl>三阶要素。
+
 #ground items
 manual.item.thebetweenlands.ground_algae.description=你可以很容易地在<nl>任何群系的水面上<nl>发现成片的水藻。
 manual.item.thebetweenlands.ground_arrow_arum.description=茯苓是一种多叶植物，<nl>生长在交错次元<nl>潮湿的湿地群系。
@@ -1221,6 +1351,7 @@ manual.item.thebetweenlands.ground_aqua_middle_gem.description=水蓝元素宝�
 manual.item.thebetweenlands.ground_bladderwort_flower.description=狸藻是高大的水下植物，<nl>主要生长在深水群系，<nl>罕见地生成于粗糙岛屿群系。
 manual.item.thebetweenlands.ground_bladderwort_stalk.description=采集生长在深水群系<nl>和粗糙岛屿群系的狸藻，<nl>可以获得狸藻花<nl>和狸藻茎两种材料。
 manual.item.thebetweenlands.sap_spit.description=灵魂树的粘稠分泌物。<nl>似乎具有再生能力。
+
 manual.item.thebetweenlands.bl.elixir.foggedMind.description=中毒者的视野将被迷雾遮蔽。<nl>Geoliirgaz要素越多，药效越强。<nl>Dayuniis要素越多，药效越持久。<nl>不加入Byariis会得到开眼药水。<nl>意识混沌之药需要以下要素：
 manual.item.thebetweenlands.bl.elixir.heavyweight.description=中毒者无法挣脱水和泥巴。<nl>Yunugaz要素越多，药效越强。<nl>Yihinren要素越多，药效越持久。<nl> 不加入Byariis会得到轻功药剂。<nl>酿造超重之药需要以下要素：
 manual.item.thebetweenlands.bl.elixir.basilisk.description=中此毒者无法行动。<nl>Azuwynn要素越多，药效越强，<nl>Yihinren要素越多，药效越持久。<nl>不加入Byariis会得到蜘蛛药水。<nl>酿造蜥毒毒剂需要以下要素：
@@ -1249,6 +1380,7 @@ manual.item.thebetweenlands.bl.elixir.ripening.description=使用它能恢复残
 manual.item.thebetweenlands.bl.elixir.healing.description=使用它能恢复生命值。<nl>Yeowynn要素越多，药效越强。<nl>Ordaniis要素越多，药效越持久。<nl>添加Byariis会得到<nl>生命凋零之药。<nl>酿造治疗之酿需要以下要素：
 manual.item.thebetweenlands.bl.elixir.nimblefeet.description=使用它能增加移动速度。<nl>Yunugaz要素越多，药效越强。<nl>Ordaniis要素越多，药效越持久。<nl>添加Byariis会得到<nl>行走疲劳之药。<nl>身手敏捷之酿需要以下要素：
 manual.item.thebetweenlands.bl.elixir.strength.description=使用它能增强攻击力。<nl>Azuwynn要素越多，药效越强。<nl>Ordaniis要素越多，药效越持久。<nl>添加Byariis会得到<nl>机能虚弱之药。<nl>力量增强之酿需要以下要素：
+
 # Advancements
 
 # Adventures
@@ -1284,6 +1416,7 @@ advancements.thebetweenlands.adventurer.santa_wight.title=圣诞阴魂的小礼�
 advancements.thebetweenlands.adventurer.santa_wight.description=打开一个礼物盒
 advancements.thebetweenlands.adventurer.bouldery_bois.title=重磅捣蛋鬼
 advancements.thebetweenlands.adventurer.bouldery_bois.description=被巨石怪冲撞
+
 # Fighter
 advancements.thebetweenlands.fighter.root.title=沼泽斗士
 advancements.thebetweenlands.fighter.root.description=在黑暗的沼泽为生存而战
@@ -1321,6 +1454,7 @@ advancements.thebetweenlands.fighter.staring_contest.title=大眼瞪小眼
 advancements.thebetweenlands.fighter.staring_contest.description=战胜原始恶意
 advancements.thebetweenlands.fighter.illegal_logging.title=非法采伐
 advancements.thebetweenlands.fighter.illegal_logging.description=击败灵魂树
+
 # Farmer
 advancements.thebetweenlands.farmer.root.title=沼泽农夫
 advancements.thebetweenlands.farmer.root.description=自己动手，丰衣足食
@@ -1344,6 +1478,7 @@ advancements.thebetweenlands.farmer.flower_power.title=权力归花儿
 advancements.thebetweenlands.farmer.flower_power.description=在你的农场上种花
 # advancements.thebetweenlands.farmer.pure_and_dirty.title=Pure And Dirty
 advancements.thebetweenlands.farmer.pure_and_dirty.description=将净化的沼泽土用于种植
+
 # Herbalist
 advancements.thebetweenlands.herbalist.root.title=炼药大师
 advancements.thebetweenlands.herbalist.root.description=从植物汲取大自然的力量
@@ -1357,6 +1492,7 @@ advancements.thebetweenlands.herbalist.bookworms.title=蛀书虫
 advancements.thebetweenlands.herbalist.bookworms.description=获得一本药学手册
 advancements.thebetweenlands.herbalist.fully_booked.title=全部写满
 advancements.thebetweenlands.herbalist.fully_booked.description=填满一本药学手册
+
 # Survivalist
 advancements.thebetweenlands.survivalist.root.title=生存专家
 advancements.thebetweenlands.survivalist.root.description=在沼泽里活下去
@@ -1380,6 +1516,7 @@ advancements.thebetweenlands.survivalist.hardware_laundry.title=清洗装备
 advancements.thebetweenlands.survivalist.hardware_laundry.description=净化你的武器或工具
 advancements.thebetweenlands.survivalist.onions_have_layers.title=洋葱是分层的，工具也一样
 advancements.thebetweenlands.survivalist.onions_have_layers.description=用痂壳晶包裹、保护你的工具
+
 # Craftsman
 advancements.thebetweenlands.craftsman.root.title=沼泽工匠
 advancements.thebetweenlands.craftsman.root.description=创造你的世界！
@@ -1391,6 +1528,7 @@ advancements.thebetweenlands.craftsman.efficiency.title=效率翻倍！
 advancements.thebetweenlands.craftsman.efficiency.description=合成双重硫磺熔炉
 advancements.thebetweenlands.craftsman.freebies.title=这是赠品
 advancements.thebetweenlands.craftsman.freebies.description=使用石灰粉熔炼矿石得到额外的金属锭
+
 # Miner
 advancements.thebetweenlands.miner.root.title=沼泽矿工
 advancements.thebetweenlands.miner.root.description=我们还要再深入些
@@ -1404,6 +1542,7 @@ advancements.thebetweenlands.miner.rock_bottom.title=岩石的最低点
 advancements.thebetweenlands.miner.rock_bottom.description=进入麻纹石组成的湖泊洞穴层
 advancements.thebetweenlands.miner.get_schwifty.title=像Schwifty一样迅捷
 advancements.thebetweenlands.miner.get_schwifty.description=获得一把迅捷镐
+
 # Config
 config.thebetweenlands.world_and_dimension=世界和维度
 config.thebetweenlands.world_and_dimension.tooltip=点击此处设置交错次元世界的一些属性
@@ -1436,6 +1575,7 @@ config.thebetweenlands.portal_biome_search_range=传送门群系搜索半径
 config.thebetweenlands.portal_biome_search_range.tooltip=生成一个传送门时，会在这一半径范围内搜寻合适的生物群系。如果你发现生成传送门时，不能总是搜索到合适的群系，可以调高这一数值，但需要更多的时间来生成传送门。
 config.thebetweenlands.generate_portal_in_end=在末地生成传送树
 config.thebetweenlands.generate_portal_in_end.tooltip=通过自定义传送树传送到末地后，是否在末地召唤返回传送树。
+
 config.thebetweenlands.rendering=渲染
 config.thebetweenlands.rendering.tooltip=关于游戏渲染和视觉效果的设置
 config.thebetweenlands.wisp_quality=鬼火的渲染质量
@@ -1449,14 +1589,17 @@ config.thebetweenlands.fullbright_blocks=完全发光的方块
 config.thebetweenlands.fullbright_blocks.tooltip=改善某些会在黑暗中发光的方块(如生命水晶矿石)的视觉效果。如果你发现这种方块出现材质显示异常，就将此项设为false
 config.thebetweenlands.sky_rift_clouds=天眼效果时显示云
 config.thebetweenlands.sky_rift_clouds.tooltip=如果设为true，天眼效果时裂缝中显示的主世界天空里会显示云。
+
 config.thebetweenlands.general=游戏机制
 config.thebetweenlands.general.tooltip=主要与游戏机制有关的选项
 config.thebetweenlands.bl_main_menu=交错次元风格的主菜单
 config.thebetweenlands.bl_main_menu.tooltip=设为true时，用交错次元风格的主菜单替换默认主菜单
 config.thebetweenlands.rowboat_view=用第三人称视角划船
 config.thebetweenlands.rowboat_view.tooltip=设为true时，玩家驾驶杂草木船时会被切换到第三人称视角
-config.thebetweenlands.use_food_sickness=启用挑食机制
-config.thebetweenlands.use_food_sickness.tooltip=设为true时启用挑食机制
+config.thebetweenlands.use_food_sickness=在交错次元启用挑食机制
+config.thebetweenlands.use_food_sickness.tooltip=设为true时在交错次元启用挑食机制
+config.thebetweenlands.use_food_sickness_outside_betweenlands=在交错次元外启用挑食机制
+config.thebetweenlands.use_food_sickness_outside_betweenlands.tooltip=设为true时在交错次元外启用挑食机制
 config.thebetweenlands.use_rotten_food=启用食物腐烂机制
 config.thebetweenlands.use_rotten_food.tooltip=设为true时启用食物腐烂机制
 config.thebetweenlands.use_decay=启用玩家残蚀值机制
@@ -1523,18 +1666,49 @@ config.thebetweenlands.equipment_zone_offset_x=装备栏X轴偏移
 config.thebetweenlands.equipment_zone_offset_x.tooltip=装备栏相对于装备区域的X轴偏移
 config.thebetweenlands.equipment_zone_offset_y=装备栏Y轴偏移
 config.thebetweenlands.equipment_zone_offset_y.tooltip=装备栏相对于装备区域的Y轴偏移
+config.thebetweenlands.decay_bar_zone=残蚀值条区域
+config.thebetweenlands.decay_bar_zone.tooltip=残蚀值条显示在HUD上的区域：\n0: 快捷栏\n1: 顶部左侧\n2: 顶部右侧\n3: 底部右侧\n4: 底部左侧\n5: 中心左侧\n6: 中心顶部\n7: 中心右侧\n8: 中心底部
+config.thebetweenlands.decay_bar_zone_offset_x=残蚀值条X轴偏移
+config.thebetweenlands.decay_bar_zone_offset_x.tooltip=残蚀值条相对于残蚀值条区域的X轴偏移
+config.thebetweenlands.decay_bar_zone_offset_y=残蚀值条Y轴偏移
+config.thebetweenlands.decay_bar_zone_offset_y.tooltip=残蚀值条相对于残蚀值条区域的Y轴偏移
+config.thebetweenlands.decay_percentage=使用百分比残蚀值
+config.thebetweenlands.decay_percentage.tooltip=是否按照百分比计算残蚀值引起的血量减少
+config.thebetweenlands.decay_min_health=最小残蚀血量
+config.thebetweenlands.decay_min_health.tooltip=不按百分比计算残蚀血量时，玩家的最小血量
+config.thebetweenlands.decay_min_health_percent=最小百分比残蚀血量
+config.thebetweenlands.decay_min_health_percent.tooltip=按百分比计算残蚀血量时，玩家的最小血量
+
+config.thebetweenlands.decay_bar_zone_offset_y=残蚀值条Y轴偏移
+config.thebetweenlands.decay_percentage=使用百分比残蚀值
+config.thebetweenlands.decay_percentage.tooltip=是否按照百分比计算残蚀值引起的血量减少
+config.thebetweenlands.decay_min_health=最小残蚀血量
+config.thebetweenlands.decay_min_health.tooltip=不按百分比计算残蚀血量时，玩家的最小血量
+config.thebetweenlands.decay_min_health_percent=最小百分比残蚀血量
+config.thebetweenlands.decay_min_health_percent.tooltip=按百分比计算残蚀血量时，玩家的最小血量
+
+config.thebetweenlands.decay_bar_zone_offset_y=残蚀值条Y轴偏移
+config.thebetweenlands.decay_percentage=使用百分比残蚀值
+config.thebetweenlands.decay_percentage.tooltip=是否按照百分比计算残蚀值引起的血量减少
+config.thebetweenlands.decay_min_health=最小残蚀血量
+config.thebetweenlands.decay_min_health.tooltip=不按百分比计算残蚀血量时，玩家的最小血量
+config.thebetweenlands.decay_min_health_percent=最小百分比残蚀血量
+config.thebetweenlands.decay_min_health_percent.tooltip=按百分比计算残蚀血量时，玩家的最小血量
+
 config.thebetweenlands.mob_spawning=生物生成
 config.thebetweenlands.mob_spawning.tooltip=与生物生成机制有关的选项
 config.thebetweenlands.max_entities_per_loaded_area=每个加载区域的最大实体数
 config.thebetweenlands.max_entities_per_loaded_area.tooltip=每个已加载的区域内(多数情况下，指每个玩家已经加载的区域)，自然生成的实体的最大数量
 config.thebetweenlands.hard_entity_limit=每个世界的最大实体数
 config.thebetweenlands.hard_entity_limit.tooltip=在每个交错次元世界，自然生成的实体的最大数量
+
 config.thebetweenlands.compatibility=兼容性
 config.thebetweenlands.compatibility.tooltip=与交错次元模组与其他模组兼容性有关的选项
 config.thebetweenlands.show_non_bl_fluids=改变其他模组桶装液体的材质
 config.thebetweenlands.show_non_bl_fluids.tooltip=设为true时，在创造模式物品栏或JEI中，其他模组的桶装液体会被显示成交错次元的桶装液体样式
 config.thebetweenlands.show_non_bl_gem_recipes=JEI显示非交错次元模组的宝石配方
 config.thebetweenlands.show_non_bl_gem_recipes.tooltip=设为true时，不是交错次元模组的物品也会在JEI中显示与元素宝石合成的配方
+
 config.thebetweenlands.online_event_overrides=高级天气事件控制机制
 config.thebetweenlands.online_event_overrides.tooltip=允许开发者远程控制天气事件的机制，及其有关的选项
 config.thebetweenlands.online_event_overrides_enabled=启用高级控制机制
@@ -1542,13 +1716,24 @@ config.thebetweenlands.check_interval=检查间隔
 config.thebetweenlands.failed_recheck_interval=失败后重新检查间隔
 config.thebetweenlands.failed_recheck_count=重新检查次数
 config.thebetweenlands.default_remote_reset_time=默认远程复位时间
+
 config.thebetweenlands.debug=调试
 config.thebetweenlands.debug.tooltip=开发者调试和开发可能需要的选项
 config.thebetweenlands.debug_mode=调试模式
 config.thebetweenlands.debug_model_loader=调试模型加载器
 config.thebetweenlands.debug_recipe_overrides=调试配方覆盖机制
+config.thebetweenlands.dump_packed_textures=处理打包的材质
+
 # Damage sources
 death.attack.bl.shockwave=%1$s 死于冲击波
 death.attack.bl.spikewave=%1$s 被根须刺穿了
-advancements.thebetweenlands.farmer.mr_compost.title=堆肥先生
-advancements.thebetweenlands.farmer.pure_and_dirty.title=纯洁而又肮脏
+
+#Dev thing
+item.thebetweenlands.test_item_chimp_ruler.name=测试尺
+tooltip.chimp_ruler.homex=Home X: %s
+tooltip.chimp_ruler.homey=Home Y: %s
+tooltip.chimp_ruler.homez=Home Z: %s
+
+chat.chimp_ruler_x=目标 X: %s
+chat.chimp_ruler_y=目标 Y: %s
+chat.chimp_ruler_z=目标 Z: %s

--- a/project/assets/thebetweenlands/lang/zh_cn.lang
+++ b/project/assets/thebetweenlands/lang/zh_cn.lang
@@ -1722,7 +1722,7 @@ config.thebetweenlands.debug.tooltip=开发者调试和开发可能需要的选�
 config.thebetweenlands.debug_mode=调试模式
 config.thebetweenlands.debug_model_loader=调试模型加载器
 config.thebetweenlands.debug_recipe_overrides=调试配方覆盖机制
-config.thebetweenlands.dump_packed_textures=处理打包的材质
+config.thebetweenlands.dump_packed_textures=导出打包的材质
 
 # Damage sources
 death.attack.bl.shockwave=%1$s 死于冲击波


### PR DESCRIPTION
这次提交的语言文件中有几个翻译疑点，希望翻译大佬们能帮我考虑一下如何翻译。
`tile.thebetweenlands.edge_shroom.name=边缘蘑菇`这一项；
`tile.thebetweenlands.dungeon_door_combination.name=地牢门密码`这一项；
`config.thebetweenlands.dump_packed_textures=处理打包的材质`中的Dump一词。
其他的我还没有发现。

- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
