### PR TITLE
更新交错次元的语言文件

### DIFF
--- a/project/assets/thebetweenlands/lang/zh_cn.lang
+++ b/project/assets/thebetweenlands/lang/zh_cn.lang
@@ -780,6 +780,7 @@ item.thebetweenlands.bone_wayfinder.name=寻路之骨
 item.thebetweenlands.magic_item_magnet.name=魔法物品磁铁
 item.thebetweenlands.gem_singer.name=宝石颂唱者
 item.thebetweenlands.bark_amulet.name=树皮护身符
+item.thebetweenlands.grappling_hook.name=抓钩
 
 # Herblore
 item.thebetweenlands.elixir.dentrothyst_vial.green.name=绿色木晶药瓶
@@ -1038,6 +1039,9 @@ chat.equipment.unequipped=卸下了 %s
 chat.waystone.obstructed=你与巨石柱的链接被阻断了。
 
 chat.dungeon_door_runes.locked=地牢门密码已设置！
+
+chat.grappling_hook.max_length=绳子已达到最大长度!
+chat.grappling_hook.disconnected=抓钩已经断开了!
 
 # Damage Source
 death.attack.suffocation=沼泽之息将 %s 窒息至死 
@@ -1722,7 +1726,7 @@ config.thebetweenlands.debug.tooltip=开发者调试和开发可能需要的选�
 config.thebetweenlands.debug_mode=调试模式
 config.thebetweenlands.debug_model_loader=调试模型加载器
 config.thebetweenlands.debug_recipe_overrides=调试配方覆盖机制
-config.thebetweenlands.dump_packed_textures=导出打包的材质
+config.thebetweenlands.dump_packed_textures=处理打包的材质
 
 # Damage sources
 death.attack.bl.shockwave=%1$s 死于冲击波


### PR DESCRIPTION
刚刚发现交错次元模组的lang文件又更新了，有新的游戏内容要添加，
赶紧翻译了补上。

- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
