### PR TITLE
修复Artisan Worktable的一个翻译错误

### DIFF
--- a/project/assets/artisanworktables/lang/zh_cn.lang
+++ b/project/assets/artisanworktables/lang/zh_cn.lang
@@ -111,8 +111,8 @@ gui.artisanworktables.tooltip.button.creative.disabled=模式：生存
 gui.artisanworktables.tooltip.button.creative.enabled=模式：创造（配方制作）
 gui.artisanworktables.tooltip.button.oredict.linked=矿物辞典模式：联动
 gui.artisanworktables.tooltip.button.oredict.unlinked=矿物辞典模式：独立
-gui.artisanworktables.tooltip.button.locked.disabled=已锁定
-gui.artisanworktables.tooltip.button.locked.enabled=已解锁
+gui.artisanworktables.tooltip.button.locked.disabled=已解锁/点击锁定
+gui.artisanworktables.tooltip.button.locked.enabled=已锁定/点击解锁
 
 # Tooltip
 item.artisanworktables.tooltip.durability=耐久：%d / %d


### PR DESCRIPTION
- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)

Artisan Worktable的工作台的"锁定"/"解锁"功能的翻译反了，现已修正