### PR TITLE
Update zh_cn.lang

### DIFF
--- a/project/assets/zollerngalaxy/lang/zh_cn.lang
+++ b/project/assets/zollerngalaxy/lang/zh_cn.lang
@@ -171,10 +171,10 @@ tile.xantheonironore.name=赞比昂铁矿石
 tile.xantheoncoalore.name=赞比昂煤矿石
 tile.xantheonnickelore.name=赞比昂镍矿石
 tile.xantheoncopperore.name=赞比昂铜矿石
-tile.xantheonfueltoniumore.name=赞比昂加尔顿矿石
+tile.xantheonfueltoniumore.name=赞比昂铀矿石
 tile.xantheonamaranthore.name=赞比昂紫苋矿石
 tile.plutoniumblock.name=钚块
-tile.fueltoniumblock.name=加尔顿块
+tile.fueltoniumblock.name=铀块
 tile.constructblock.name=构造块
 
 tile.candycube_white.name=白色糖果立方
@@ -237,9 +237,9 @@ whitelava=放射性熔岩
 tile.whitelava.name=放射性熔岩
 fluid.whitelava=放射性熔岩
 
-fueltonium=熔融加尔顿
-tile.fueltonium.name=熔融加尔顿
-fluid.fueltonium=熔融加尔顿
+fueltonium=熔融铀
+tile.fueltonium.name=熔融铀
+fluid.fueltonium=熔融铀
 
 chocolatemelted=液态巧克力
 tile.chocolatemelted.name=液态巧克力
@@ -288,8 +288,8 @@ item.plutoniumcrystal.name=钚水晶
 
 item.purgotessence.name=绿洲星宝石
 
-item.fueltoniumraw.name=加尔顿原矿
-item.fueltoniumingot.name=加尔顿锭
+item.fueltoniumraw.name=铀原矿
+item.fueltoniumingot.name=铀锭
 
 item.chargiumdust.name=碳导体合金粉
 item.chargiumingot.name=碳导体合金锭


### PR DESCRIPTION
Fueltonium其实就是铀...我当初还在想音译成什么好 后来发现它矿物词典写的是铀

- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
