### PR TITLE
修正“悲伤之木”系列方块的翻译，改为“阴暗之木”

### DIFF
--- a/project/assets/defiledlands/lang/zh_cn.lang
+++ b/project/assets/defiledlands/lang/zh_cn.lang
@@ -17,24 +17,24 @@ tile.defiledlands.stone_defiled_decoration.bricks.name=污秽之石砖
 tile.defiledlands.stone_defiled_decoration.bricks_cracked.name=污秽裂石砖
 tile.defiledlands.stone_defiled_decoration.bricks_mossy.name=污秽苔石砖
 tile.defiledlands.stone_defiled_decoration.mossy.name=污秽苔石
-tile.defiledlands.tenebra_door.name=悲伤木门
+tile.defiledlands.tenebra_door.name=阴暗木门
 tile.defiledlands.stone_defiled_slab.stone.name=污秽之石台阶
 tile.defiledlands.stone_defiled_slab.sandstone.name=污秽沙石台阶
 tile.defiledlands.stone_defiled_slab.bricks.name=污秽石砖台阶
-tile.defiledlands.wood_defiled_slab.tenebra.name=悲伤之木台阶
+tile.defiledlands.wood_defiled_slab.tenebra.name=阴暗之木台阶
 tile.defiledlands.stone_defiled_stairs.name=污秽之石楼梯
 tile.defiledlands.sandstone_defiled_stairs.name=污秽沙石楼梯
 tile.defiledlands.stone_defiled_bricks_stairs.name=污秽石砖楼梯
-tile.defiledlands.tenebra_stairs.name=悲伤之木楼梯
+tile.defiledlands.tenebra_stairs.name=阴暗之木楼梯
 tile.defiledlands.ravaging_decoration.stone.name=毁灭石
 tile.defiledlands.ravaging_decoration.bricks.name=毁灭砖
 tile.defiledlands.glass_obscure.name=浑浊玻璃
 tile.defiledlands.glass_obscure.tooltip=阻挡光线
 
-tile.defiledlands.tenebra_log.name=悲伤之木
-tile.defiledlands.tenebra_leaves.name=悲伤树叶
-tile.defiledlands.tenebra_sapling.name=悲伤树苗
-tile.defiledlands.tenebra_planks.name=悲伤之木木板
+tile.defiledlands.tenebra_log.name=阴暗之木
+tile.defiledlands.tenebra_leaves.name=阴暗树叶
+tile.defiledlands.tenebra_sapling.name=阴暗树苗
+tile.defiledlands.tenebra_planks.name=阴暗之木木板
 tile.defiledlands.vilespine.name=邪恶荆棘
 tile.defiledlands.blastem.name=爆炸植物
 tile.defiledlands.scuronotte.name=黑夜蘑菇
@@ -54,7 +54,7 @@ tile.defiledlands.conjuring_altar.name=招魂坛
 #----------------------------
 #Items
 #----------------------------
-item.defiledlands.tenebra_door.name=悲伤木门
+item.defiledlands.tenebra_door.name=阴暗木门
 
 item.defiledlands.hephaestite.name=赫菲斯辛碎片
 item.defiledlands.umbrium_ingot.name=影素锭
@@ -235,7 +235,7 @@ advancements.defiledlands.summon_destroyer.description=在激活的招魂坛上�
 advancements.defiledlands.ravaging_tool.title=掌控毁灭的人
 advancements.defiledlands.ravaging_tool.description=用毁灭精华制作工具
 advancements.defiledlands.summon_mourner.title=死寂中垂泪的人
-advancements.defiledlands.summon_mourner.description=在激活的招魂坛上使用悲伤人偶
+advancements.defiledlands.summon_mourner.description=在激活的招魂坛上使用阴暗人偶
 
 advancements.defiledlands.book_wyrm_breed.title=爱的气味
 advancements.defiledlands.book_wyrm_breed.description=用怪味糖喂食两只书卷之龙

--- a/project/assets/defiledlands/lang/zh_cn.lang
+++ b/project/assets/defiledlands/lang/zh_cn.lang
@@ -235,7 +235,7 @@ advancements.defiledlands.summon_destroyer.description=在激活的招魂坛上�
 advancements.defiledlands.ravaging_tool.title=掌控毁灭的人
 advancements.defiledlands.ravaging_tool.description=用毁灭精华制作工具
 advancements.defiledlands.summon_mourner.title=死寂中垂泪的人
-advancements.defiledlands.summon_mourner.description=在激活的招魂坛上使用阴暗人偶
+advancements.defiledlands.summon_mourner.description=在激活的招魂坛上使用悲伤人偶
 
 advancements.defiledlands.book_wyrm_breed.title=爱的气味
 advancements.defiledlands.book_wyrm_breed.description=用怪味糖喂食两只书卷之龙


### PR DESCRIPTION
修正理由：
> 建议更正一下译名，[Tenebra 是意大利语中“黑暗”的意思](https://www.yihan.it/tenebra)，
结合该模组的基调，翻译成“阴暗”更为合适。
因此，“悲伤之木”等名字都建议修改一下。

—— MCMOD 百科用户 @Ethaxiuman 的建议，
来自 [污秽之地 MCMOD 百科短评区](https://www.mcmod.cn/class/2133.html)。

- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
