### PR TITLE
纠正一处拼写错误

### DIFF
--- a/src/LangPack/Pack/Program.cs
+++ b/src/LangPack/Pack/Program.cs
@@ -34,7 +34,7 @@ namespace Pack
                 .Append(new { src = @"./database/asset_map.json", dest = @"assets/i18nmod/asset_map/asset_map.json" });
 
             Directory.CreateDirectory(@"./out");
-            Console.WriteLine($"Totall found {paths.CountAsync()} files ");
+            Console.WriteLine($"Totally found {paths.CountAsync()} files ");
             await using (var zipFile = File.OpenWrite(@"./Minecraft-Mod-Language-Modpack.zip"))
             {
                 using var zipArchive = new ZipArchive(zipFile, ZipArchiveMode.Create);


### PR DESCRIPTION

- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)

"Totall"应该是"Totally"吧。
