### PR TITLE
补充MysticalWorld模组的本地化

### DIFF
--- a/project/assets/mysticalworld/lang/zh_cn.lang
+++ b/project/assets/mysticalworld/lang/zh_cn.lang
@@ -1,4 +1,4 @@
-itemGroup.mysticalworld=神秘世界
+itemGroup.mysticalworld=魔幻世界
 
 entity.entity_fox.name=狐狸
 entity.entity_frog.name=青蛙
@@ -13,8 +13,17 @@ entity.entity_obsidian_cat.name=黑曜石豹猫
 
 item.carapace.name=甲壳
 item.pelt.name=毛皮
+item.raw_squid.name=生鱿鱼
+item.cooked_squid.name=熟鱿鱼
+item.epic_squid.name=史诗鱿鱼
+item.unripe_pearl.name=不完整的末影珍珠
+item.silk_thread.name=丝线
+item.silk_cocoon.name=蚕茧
+item.spindle.name=纺锤
+item.silkworm_egg.name=蚕卵
+item.cooked_apple.name=熟苹果
 
-# Ingots
+#金属锭
 item.copper_ingot.name=铜锭
 item.tin_ingot.name=锡锭
 item.silver_ingot.name=银锭
@@ -28,7 +37,7 @@ item.brass_ingot.name=黄铜锭
 item.bronze_ingot.name=青铜锭
 item.amethyst_gem.name=紫水晶
 
-# Nuggets
+#金属粒
 item.copper_nugget.name=铜粒
 item.tin_nugget.name=锡粒
 item.silver_nugget.name=银粒
@@ -41,7 +50,7 @@ item.electrum_nugget.name=琥珀金粒
 item.brass_nugget.name=黄铜粒
 item.bronze_nugget.name=青铜粒
 
-# Metal Blocks
+# Metal 块s
 tile.copper_block.name=铜块
 tile.tin_block.name=锡块
 tile.silver_block.name=银块
@@ -55,13 +64,13 @@ tile.brass_block.name=黄铜块
 tile.bronze_block.name=青铜块
 tile.amethyst_block.name=紫水晶块
 
-# Dusts
+#粉s
 item.copper_dust.name=铜粉
 item.tin_dust.name=锡粉
 item.silver_dust.name=银粉
 item.lead_dust.name=铅粉
 item.nickel_dust.name=镍粉
-item.aluminum_dust.name=铝粉
+item.aluminum_dust.name=Aluminum粉
 item.zinc_dust.name=锌粉
 item.invar_dust.name=因瓦合金粉
 item.electrum_dust.name=琥珀金粉
@@ -71,29 +80,29 @@ item.bronze_dust.name=青铜粉
 item.iron_dust.name=铁粉
 item.gold_dust.name=金粉
 
-# Tiny Dusts
-item.copper_dust_tiny.name=小撮铜粉
-item.tin_dust_tiny.name=小撮锡粉
-item.silver_dust_tiny.name=小撮银粉
-item.lead_dust_tiny.name=小撮铅粉
-item.nickel_dust_tiny.name=小撮镍粉
-item.aluminum_dust_tiny.name=小撮铝粉
-item.zinc_dust_tiny.name=小撮锌粉
-item.invar_dust_tiny.name=小撮因瓦合金粉
-item.electrum_dust_tiny.name=小撮琥珀金粉
-item.brass_dust_tiny.name=小撮黄铜粉
-item.bronze_dust_tiny.name=小撮青铜粉
+# 锡y粉s
+item.copper_dust_tiny.name=小堆铜粉
+item.tin_dust_tiny.name=小堆锡粉
+item.silver_dust_tiny.name=小堆银粉
+item.lead_dust_tiny.name=小堆铅粉
+item.nickel_dust_tiny.name=小堆镍粉
+item.aluminum_dust_tiny.name=小堆铝粉
+item.zinc_dust_tiny.name=小堆锌粉
+item.invar_dust_tiny.name=小堆因瓦合金粉
+item.electrum_dust_tiny.name=小堆琥珀金粉
+item.brass_dust_tiny.name=小堆黄铜粉
+item.bronze_dust_tiny.name=小堆青铜粉
 
-item.iron_dust_tiny.name=小撮铁粉
-item.gold_dust_tiny.name=小撮金粉
+item.iron_dust_tiny.name=小堆铁粉
+item.gold_dust_tiny.name=小堆金粉
 
-# Ores
+#矿石s
 tile.copper_ore.name=铜矿石
 tile.tin_ore.name=锡矿石
 tile.silver_ore.name=银矿石
 tile.lead_ore.name=铅矿石
 tile.nickel_ore.name=镍矿石
-tile.aluminum_ore.name=铝矿石
+tile.aluminum_ore.name=Aluminum矿石
 tile.zinc_ore.name=锌矿石
 tile.amethyst_ore.name=紫水晶矿石
 
@@ -107,97 +116,128 @@ item.amethyst_hoe.name=紫水晶锄
 item.copper_pickaxe.name=铜镐
 item.silver_pickaxe.name=银镐
 item.amethyst_pickaxe.name=紫水晶镐
-item.copper_shovel.name=铜铲
-item.silver_shovel.name=银铲
-item.amethyst_shovel.name=紫水晶铲
+item.copper_shovel.name=铜锹
+item.silver_shovel.name=银锹
+item.amethyst_shovel.name=紫水晶锹
 item.copper_sword.name=铜剑
 item.silver_sword.name=银剑
-item.amethyst_sword.name=紫水晶之剑
-item.silver_knife.name=铜刀
-item.copper_knife.name=银刀
-item.amethyst_knife.name=紫水晶刀
+item.amethyst_sword.name=紫水晶剑
+item.silver_knife.name=银匕首
+item.copper_knife.name=铜匕首
+item.amethyst_knife.name=紫水晶匕首
 
+# Embers Metals
 item.dawnstone_ingot.name=黎明石锭
 item.sooty_iron_ingot.name=乌铁锭
 
 item.dawnstone_nugget.name=黎明石粒
 item.sooty_iron_nugget.name=乌铁粒
 
-tile.dawnstone_block.name=黎明石块
-tile.sooty_iron_block.name=乌铁块
+tile.dawnstone_block.name=黎明石
+tile.sooty_iron_block.name=乌铁
 
-tile.charred_planks.name=烧焦的木板
-tile.charred_log.name=烧焦的原木
-tile.charred_stairs.name=烧焦的楼梯
-tile.charred_slab.name=烧焦的台阶
-tile.charred_wall.name=烧焦的木墙
-tile.charred_button.name=烧焦的按钮
-tile.charred_pressure_plate.name=烧焦的压力板
-tile.charred_fence.name=烧焦的栅栏
+# 方镁矾
+tile.caminite.name=方镁矾块
+tile.caminite_stairs.name=方镁矾楼梯
+tile.caminite_slab.name=方镁矾台阶
+tile.caminite_double_slab.name=方镁矾双台阶
+tile.caminite_wall.name=方镁矾墙
 
+tile.caminite_bricks.name=方镁矾砖
+tile.caminite_bricks_stairs.name=方镁矾砖楼梯
+tile.caminite_bricks_slab.name=方镁矾砖台阶
+tile.caminite_bricks_double_slab.name=方镁矾砖双台阶
+tile.caminite_bricks_wall.name=方镁矾砖墙
 
+# 泥块
 tile.wet_mud_brick.name=湿润的泥砖
 tile.wet_mud_block.name=湿润的泥块
 tile.mud_brick.name=泥砖
-tile.mud_block.name=无机盐泥块
-tile.mud_block_stairs.name=无机盐泥块楼梯
-tile.mud_block_slab.name=无机盐泥块台阶
-tile.mud_block_wall.name=无机盐泥块墙
-tile.mud_block_button.name=无机盐泥块按钮
-tile.mud_block_pressure_plate.name=无机盐泥块压力板
-tile.mud_block_fence.name=无机盐泥块栅栏
+tile.mud_block.name=泥块
+tile.mud_block_stairs.name=泥块楼梯
+tile.mud_block_slab.name=泥块台阶
+tile.mud_block_wall.name=泥块墙
+tile.mud_block_button.name=泥块按钮
+tile.mud_block_pressure_plate.name=泥块压力板
+tile.mud_block_fence.name=泥块栅栏
+tile.mud_block_fence_gate.name=泥块栅栏门
 tile.mud_brick_stairs.name=泥砖楼梯
 tile.mud_brick_slab.name=泥砖台阶
 tile.mud_brick_wall.name=泥砖墙
 tile.mud_brick_button.name=泥砖按钮
 tile.mud_brick_pressure_plate.name=泥砖压力板
 tile.mud_brick_fence.name=泥砖栅栏
+tile.mud_brick_fence_gat.ename=泥砖栅栏门
 
-# Caminite方镁矾(不知道为啥有余烬的材料)
-tile.caminite.name=方镁矾块
-tile.caminite_stairs.name=方镁矾楼梯
-tile.caminite_slab.name=方镁矾台阶
-tile.caminite_double_slab.name=方镁矾双层台阶
-tile.caminite_wall.name=方镁矾墙
-
-tile.caminite_bricks.name=方镁矾砖
-tile.caminite_bricks_stairs.name=方镁矾砖楼梯
-tile.caminite_bricks_slab.name=方镁矾砖台阶
-tile.caminite_bricks_double_slab.name=方镁矾砖双层台阶
-tile.caminite_bricks_wall.name=方镁矾砖墙
+# 烧焦的方块
+tile.charred_planks.name=烧焦的木板
+tile.charred_log.name=烧焦的原木
+tile.charred_stairs.name=烧焦的楼梯
+tile.charred_slab.name=烧焦的台阶
+tile.charred_wall.name=烧焦的墙
+tile.charred_button.name=烧焦的按钮
+tile.charred_pressure_plate.name=烧焦的压力板
+tile.charred_fence.name=烧焦的栅栏
+tile.charred_fence_gate.name=烧焦的栅栏门
 
 #Solar Infused
 tile.solar_infused_stone.name=太阳能灌注石
 tile.solar_infused_stone_stairs.name=太阳能灌注石楼梯
 tile.solar_infused_stone_slab.name=太阳能灌注石台阶
-tile.solar_infused_stone_double_slab.name=太阳能灌注石双层台阶
-tile.solar_infused_stone_wall.name=太阳能灌注石砖墙
+tile.solar_infused_stone_double_slab.name=太阳能灌注石双台阶
+tile.solar_infused_stone_wall.name=太阳能灌注石墙
 
 #Advancements
-advancement.mysticalworld.root=神秘的世界
-advancement.mysticalworld.root.desc=在一个一个全新的，神秘的世界呼吸！
-advancement.mysticalworld.amethyst=清醒测试
-advancement.mysticalworld.amethyst.desc=找一颗比钻石更神圣的宝石！
-advancement.mysticalworld.aubergine=这不是胡萝卜......
-advancement.mysticalworld.aubergine.desc=曾经，紫色的胡萝卜风靡一时。但这是一个茄子。
-advancement.mysticalworld.epic_squid=史诗级鱿鱼！
-advancement.mysticalworld.epic_squid.desc=感受史诗鱿鱼的美味。
+advancement.mysticalworld.root=魔幻世界
+advancement.mysticalworld.root.desc=呼吸来自全新魔幻世界的空气！
+advancement.mysticalworld.amethyst=你醉了吗？
+advancement.mysticalworld.amethyst.desc=挖到一块比钻石更珍贵的紫水晶
+advancement.mysticalworld.aubergine=比胡萝卜好
+advancement.mysticalworld.aubergine.desc=紫色的萝卜曾风靡一时，但这是茄子
+advancement.mysticalworld.epic_squid=史诗鱿鱼！
+advancement.mysticalworld.epic_squid.desc=吃一口神奇的史诗鱿鱼
 
 item.venison.name=鹿肉
 item.cooked_venison.name=烤鹿肉
 item.antlers.name=鹿角
-item.ink_bottle.name=一瓶墨水
+item.ink_bottle.name=墨水瓶
 item.aubergine_seed.name=茄子种子
 item.aubergine.name=茄子
 item.cooked_aubergine.name=烤茄子
 item.stuffed_aubergine.name=酿茄子
-item.epic_squid.name=史诗鱿鱼
-item.raw_squid.name=生鱿鱼
-item.cooked_squid.name=熟鱿鱼
-item.unripe_pearl.name=不完整的末影珍珠
-item.silk_thread.name=丝线
-item.silk_cocoon.name=蚕茧
-item.spindle.name=纺锤
-item.silkworm_egg.name=蚕卵
 
-message.squid.cooldown=给它时间生产更多墨水！
+message.squid.cooldown=鱿鱼还没有产生足够的墨水！
+
+# Sounds
+mysticalworld.subtitles.entity.fox.aggro=狐狸:啸叫
+mysticalworld.subtitles.entity.fox.bark=狐狸:吼叫
+mysticalworld.subtitles.entity.fox.bite=狐狸:撕咬
+mysticalworld.subtitles.entity.fox.death=狐狸:死亡
+mysticalworld.subtitles.entity.fox.eat=狐狸:吞食
+mysticalworld.subtitles.entity.fox.idle=狐狸:漫步
+mysticalworld.subtitles.entity.fox.sleep=狐狸:睡眠
+mysticalworld.subtitles.entity.fox.sniff=狐狸:抽鼻
+mysticalworld.subtitles.entity.fox.spit=狐狸:吐东西
+mysticalworld.subtitles.entity.sprout.ambient=芽精灵:漫步
+mysticalworld.subtitles.entity.endermini.death=迷你末影人:死亡
+mysticalworld.subtitles.entity.endermini.hit=迷你末影人:受伤
+mysticalworld.subtitles.entity.endermini.idle=迷你末影人:低语
+mysticalworld.subtitles.entity.endermini.portal=迷你末影人:传送
+mysticalworld.subtitles.entity.endermini.scream=迷你末影人:尖叫
+mysticalworld.subtitles.entity.endermini.stare=迷你末影人:愤怒
+mysticalworld.subtitles.entity.silkworm.egg.use=蚕卵:破壳
+mysticalworld.subtitles.entity.lava_cat.sizzle=岩浆豹猫:嘶嘶声
+mysticalworld.subtitles.entity.frog.slime=青蛙:吐出粘液
+mysticalworld.subtitles.entity.lava_cat.ambient=岩浆豹猫:喵喵
+mysticalworld.subtitles.entity.lava_cat.death=岩浆豹猫:死亡
+mysticalworld.subtitles.entity.lava_cat.受伤=岩浆豹猫:受伤
+mysticalworld.subtitles.entity.lava_cat.purr=岩浆豹猫:呼噜
+mysticalworld.subtitles.entity.lava_cat.purreow=岩浆豹猫:呼噜
+mysticalworld.subtitles.entity.silkworm.plop=蚕:成长
+mysticalworld.subtitles.entity.squid.milk=鱿鱼:喷墨
+mysticalworld.subtitles.item.unripe_pearl.use=不完整的末影珍珠:传送
+mysticalworld.subtitles.entity.silkworm.ambient=蚕:吱吱
+mysticalworld.subtitles.entity.silkworm.death=蚕:死亡
+mysticalworld.subtitles.entity.silkworm.受伤=蚕:受伤
+mysticalworld.subtitles.entity.silkworm.step=蚕:漫步
+mysticalworld.subtitles.entity.silkworm.eat=蚕:进食

--- a/project/assets/mysticalworld/patchouli_books/world_guide/book.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/book.json
@@ -1,0 +1,18 @@
+{
+	"name": "魔幻世界漫游记",
+	"advancement_namespaces": [
+		"mysticalworld"
+	],
+	"creative_tab": "mysticalworld",
+	"advancements_tab": "mysticalworld",
+	"landing_text": "这是一个美丽的魔法世界！$(br2)这本书将介绍$(br)$(l)奇妙神秘的魔法事物$()，$(br)给予你必要的引导知识。",
+	"book_texture": "mysticalworld:textures/gui/book.png",
+	"filler_texture": "mysticalworld:textures/gui/patchouli/book_filler.png",
+	"model": "mysticalworld:guidebook",
+	"version": 1,
+	"show_progress": false,
+	"macros": {
+		"$(info)": "$(thing)$(bold)$(t:Important Detail)[!]$()",
+		"$(warning)": "$(#f00)$(bold)$(t:Warning)[!]$()"
+	}
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/blocks.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/blocks.json
@@ -1,0 +1,6 @@
+{
+    "name": "方块",
+    "sortnum" : 0,
+    "description": "介绍这个美丽世界当中的奇妙方块。",
+    "icon": "mysticalworld:mud_brick"
+  }

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/creatures.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/creatures.json
@@ -1,0 +1,6 @@
+{
+  "name": "生物",
+  "sortnum" : 1,
+  "description": "介绍居住在这片奇妙土地上的生物。",
+  "icon": "mysticalworld:antlers"
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/crops.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/crops.json
@@ -1,0 +1,6 @@
+{
+  "name": "农作物",
+  "sortnum" : 2,
+  "description": "种植它们来获取自然的力量！",
+  "icon": "mysticalworld:aubergine"
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/cuisine.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/cuisine.json
@@ -1,0 +1,6 @@
+{
+    "name": "美食",
+    "sortnum" : 4,
+    "description": "这里有奇妙的美食等着你品尝！",
+    "icon": "mysticalworld:cooked_squid"
+  }

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/features.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/features.json
@@ -1,0 +1,6 @@
+{
+  "name": "自然生成",
+  "sortnum" : 7,
+  "description": "除了那些前人遗留的建筑，$(br)有趣的自然生成也等待你的发现！",
+  "icon": "mysticalworld:charred_log"
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/items.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/items.json
@@ -1,0 +1,6 @@
+{
+  "name": "物品",
+  "sortnum" : 7,
+  "description": "这些奇妙的物品，可以在这美丽的土地上找到。",
+  "icon": "mysticalworld:unripe_pearl"
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/locations.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/locations.json
@@ -1,0 +1,6 @@
+{
+  "name": "探索",
+  "sortnum" : 6,
+  "description": "在这片土地上有许自然生成的建筑，$(br)其中有些已经荒废，$(br)有些似乎还被$(l)神秘的力量$()掌控着...",
+  "icon": "mysticalworld:thatch"
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/ores.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/categories/ores.json
@@ -1,0 +1,6 @@
+{
+  "name": "矿石",
+  "sortnum" : 5,
+  "description": "许多的矿石生成在地下，$(br)它们中有些显得无趣，有的却隐藏着魔力...",
+  "icon": "mysticalworld:amethyst_ore"
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/blocks/charred_wood.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/blocks/charred_wood.json
@@ -1,0 +1,47 @@
+{
+  "name": "烧焦的原木",
+  "icon": "mysticalworld:charred_log",
+  "category": "blocks",
+  "pages": [
+    {
+      "type": "spotlight",
+      "link_recipe": true,
+      "item": "mysticalworld:charred_log",
+      "text": "你可以找到被雷电击中或者被野火烧焦的树木，它们现在主要作为装饰用途了。$(br2)你也可以用打火石和原版原木合成得到烧焦的原木，损耗打火石的1点耐久；用火焰弹合成也可以，但是会消耗火焰弹。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:charred_wood_eight",
+      "recipe2": "mysticalworld:charred_wood"
+    },
+    {
+      "type": "crafting",
+      "link_recipe": true,
+      "recipe": "mysticalworld:charred_planks",
+      "text": "烧焦的原木也可以像原版原木一样分解为木板。"
+    },
+    {
+      "type": "crafting",
+      "link_recipe": true,
+      "recipe": "mysticalworld:charred_stairs",
+      "recipe2": "mysticalworld:charred_slab",
+      "text": "烧焦的木板可以做成相应的装饰方块。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:charred_wall",
+      "recipe2": "mysticalworld:charred_fence",
+      "link_recipe": true
+    },
+    {
+      "type": "crafting",
+      "link_recipe": true,
+      "recipe": "mysticalworld:charred_button",
+      "recipe2": "mysticalworld:charred_pressure_plate"
+    },
+    {
+      "type": "smelting",
+      "recipe": "mysticalworld:charred_log"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/blocks/mud_block_decoration.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/blocks/mud_block_decoration.json
@@ -1,0 +1,59 @@
+{
+  "name": "用泥砖做建材！",
+  "icon": "mysticalworld:mud_block_stairs",
+  "category": "blocks",
+  "pages": [
+    {
+      "type": "spotlight",
+      "item": "mysticalworld:mud_block_stairs",
+      "link_recipe": true,
+      "text": "用无机盐泥块和泥砖都可以合成对应的楼梯。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:mud_block_stairs",
+      "recipe2": "mysticalworld:mud_brick_stairs",
+      "link_recipe": true,
+      "title": "楼梯"
+    },
+    {
+      "type": "spotlight",
+      "item": "mysticalworld:mud_block_slab",
+      "link_recipe": true,
+      "text": "用无机盐泥块和泥砖都可以合成对应的台阶。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:mud_block_slab",
+      "recipe2": "mysticalworld:mud_brick_slab",
+      "link_recipe": true,
+      "title": "台阶"
+    },
+    {
+      "type": "spotlight",
+      "item": "mysticalworld:mud_block_wall",
+      "link_recipe": true,
+      "text": "用无机盐泥块和泥砖都可以合成对应的墙。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:mud_block_wall",
+      "recipe2": "mysticalworld:mud_brick_wall",
+      "link_recipe": true,
+      "title": "墙"
+    },
+    {
+      "type": "spotlight",
+      "item": "mysticalworld:mud_block_fence",
+      "link_recipe": true,
+      "text": "用无机盐泥块和泥砖都可以合成对应的栅栏。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:mud_block_fence",
+      "recipe2": "mysticalworld:mud_brick_fence",
+      "link_recipe": true,
+      "title": "栅栏"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/blocks/mud_block_utility.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/blocks/mud_block_utility.json
@@ -1,0 +1,33 @@
+{
+  "name": "用泥砖做红石元件！",
+  "icon": "mysticalworld:mud_block_pressure_plate",
+  "category": "blocks",
+  "pages": [
+    {
+      "type": "spotlight",
+      "item": "mysticalworld:mud_block_pressure_plate",
+      "link_recipe": true,
+      "text": "用无机盐泥块和泥砖都可以合成对应的压力板。$(br2)他们与石压力板一样只在被生物踩踏时激活。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:mud_block_pressure_plate",
+      "recipe2": "mysticalworld:mud_brick_pressure_plate",
+      "link_recipe": true,
+      "title": "压力板"
+    },
+    {
+      "type": "spotlight",
+      "item": "mysticalworld:mud_block_button",
+      "link_recipe": true,
+      "text": "用无机盐泥块和泥砖都可以合成对应的按钮。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:mud_block_button",
+      "recipe2": "mysticalworld:mud_brick_button",
+      "link_recipe": true,
+      "title": "按钮"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/blocks/mud_blocks.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/blocks/mud_blocks.json
@@ -1,0 +1,29 @@
+{
+  "name": "泥巴和泥砖",
+  "icon": "mysticalworld:wet_mud_block",
+  "category": "blocks",
+  "pages": [
+    {
+      "type": "spotlight",
+      "item": "mysticalworld:wet_mud_block",
+      "link_recipe": true,
+      "text": "合成出来以后，可以在熔炉中烘干得到泥巴和泥砖。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:wet_mud_block",
+      "recipe2": "mysticalworld:wet_mud_brick",
+      "link_recipe": true,
+      "title": "湿润的泥块",
+      "text": "湿润的泥砖可以合成获得。"
+    },
+    {
+      "type": "smelting",
+      "recipe": "mysticalworld:wet_mud_block",
+      "recipe2": "mysticalworld:wet_mud_brick",
+      "link_recipe": true,
+      "title": "熔炉烘干",
+      "text": "接下来将它们放入熔炉，烧制成泥块和泥砖。"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/beetle.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/beetle.json
@@ -1,0 +1,23 @@
+{
+  "name": "甲虫",
+  "icon": "mysticalworld:carapace",
+  "category": "creatures",
+  "flag": "roots:beetle",
+  "pages": [
+    {
+      "type": "animal_spawn_info",
+      "animal": "beetle",
+      "breed": "使用西瓜繁殖;",
+      "tame": "使用西瓜种子驯服。",
+      "blurb": "空手潜行右键点击，可以将甲虫放在肩上。"
+    },
+    {
+      "type": "entity",
+      "name": "甲虫",
+      "entity": "mysticalworld:entity_beetle",
+      "scale": 1.5,
+      "offset": -0.3,
+      "text": "空手潜行右键点击，可以将甲虫放到地上。"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/deer.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/deer.json
@@ -1,0 +1,23 @@
+{
+  "name": "鹿",
+  "icon": "mysticalworld:venison",
+  "category": "creatures",
+  "flag": "roots:deer",
+  "pages": [
+    {
+      "type": "animal_spawn_info",
+      "animal": "deer",
+      "breed": "用小麦繁殖;",
+      "tame": "不可驯服",
+      "blurb": ""
+    },
+    {
+      "type": "entity",
+      "name": "鹿",
+      "entity": "mysticalworld:entity_deer",
+      "scale": 0.6,
+      "offset": 0.4,
+      "text": "雄鹿与雌鹿结合的温驯的后代。"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/endermini.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/endermini.json
@@ -1,0 +1,23 @@
+{
+  "name": "迷你末影人",
+  "icon": "mysticalworld:unripe_pearl",
+  "category": "creatures",
+  "flag": "roots:endermini",
+  "pages": [
+    {
+      "type": "animal_spawn_info",
+      "animal": "endermini",
+      "breed": "不可繁殖;",
+      "tame": "不可驯服。",
+      "blurb": "这些可爱的小家伙还是不喜欢被人盯着！"
+    },
+    {
+      "type": "entity",
+      "name": "迷你末影人",
+      "entity": "mysticalworld:entity_endermini",
+      "scale": 0.7,
+      "offset": 0,
+      "text": "这些小生物和他们的大个子表兄末影人一起住在末地。"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/fox.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/fox.json
@@ -1,0 +1,23 @@
+{
+  "name": "狐狸",
+  "icon": "mysticalworld:pelt",
+  "category": "creatures",
+  "flag": "roots:fox",
+  "pages": [
+    {
+      "type": "animal_spawn_info",
+      "animal": "fox",
+      "breed": "用苹果繁殖;",
+      "tame": "用苹果驯服。",
+      "blurb": ""
+    },
+    {
+      "type": "entity",
+      "name": "Fox",
+      "entity": "mysticalworld:entity_fox",
+      "scale": 0.8,
+      "offset": 0,
+      "text": "野生的狐狸是兔子和鸡的杀手，但驯服后会变得温顺！"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/frog.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/frog.json
@@ -1,0 +1,23 @@
+{
+  "name": "青蛙",
+  "icon": "minecraft:slime_ball",
+  "category": "creatures",
+  "flag": "roots:frog",
+  "pages": [
+    {
+      "type": "animal_spawn_info",
+      "animal": "frog",
+      "breed": "用棕蘑菇繁殖;",
+      "tame": "不可驯服。",
+      "blurb": ""
+    },
+    {
+      "type": "entity",
+      "name": "Frog",
+      "entity": "mysticalworld:entity_frog",
+      "scale": 1.5,
+      "offset": -0.3,
+      "text": "青蛙会像鸡下蛋一样掉落粘液球！"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/lava_cat.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/lava_cat.json
@@ -1,0 +1,23 @@
+{
+  "name": "岩浆豹猫",
+  "icon": "minecraft:lava_bucket",
+  "category": "creatures",
+  "flag": "roots:lava_cat",
+  "pages": [
+    {
+      "type": "animal_spawn_info",
+      "animal": "lava_cat",
+      "breed": "用烈焰棒繁殖;",
+      "tame": "用烈焰棒驯服。",
+      "blurb": "接触水会使它变为黑曜石豹猫！"
+    },
+    {
+      "type": "entity",
+      "name": "岩浆豹猫",
+      "entity": "mysticalworld:entity_lava_cat",
+      "scale": 0.5,
+      "offset": -0.3,
+      "text": "反过来，接触岩浆会让它变回来！"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/owl.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/owl.json
@@ -1,0 +1,23 @@
+{
+  "name": "猫头鹰",
+  "icon": "minecraft:feather",
+  "category": "creatures",
+  "flag": "roots:owl",
+  "pages": [
+    {
+      "type": "animal_spawn_info",
+      "animal": "owl",
+      "breed": "用生兔肉繁殖;",
+      "tame": "不可驯服。",
+      "blurb": ""
+    },
+    {
+      "type": "entity",
+      "name": "猫头鹰",
+      "entity": "mysticalworld:entity_owl",
+      "scale": 0.7,
+      "offset": 0.3,
+      "text": ""
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/silkworm.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/silkworm.json
@@ -1,0 +1,27 @@
+{
+  "name": "蚕",
+  "icon": "mysticalworld:silk_cocoon",
+  "category": "creatures",
+  "flag": "roots:silkworm",
+  "pages": [
+    {
+      "type": "spotlight",
+      "item": "mysticalworld:silkworm_egg",
+      "text": "它们会随时间长大并产出$(l:items/silk_cocoon)蚕茧$().$(br2)它们不会在任何确定的群系生成，也不能繁殖，但是可以从蚕卵中孵化出来。"
+    },
+    {
+      "type": "entity",
+      "name": "蚕",
+      "entity": "mysticalworld:entity_silkworm",
+      "scale": 1.5,
+      "offset": -0.3,
+      "text": "你可以把树叶扔在附近加快蚕的生长。"
+    },
+    {
+      "type": "spotlight",
+      "item": "minecraft:leaves",
+      "flag": "roots:silkworm_leaves",
+      "text": "蚕既不会自然生成也不能繁殖，但是有几率从卵中孵化。$(br2)破坏树叶有几率获得蚕卵。"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/sprout.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/sprout.json
@@ -1,0 +1,22 @@
+{
+  "name": "芽精灵",
+  "icon": "mysticalworld:aubergine",
+  "category": "creatures",
+  "pages": [
+    {
+      "type": "animal_spawn_info",
+      "animal": "sprout",
+      "breed": "需特殊方法繁殖;",
+      "tame": "不可驯服。",
+      "blurb": "不同颜色的芽精灵会掉落不同的蔬菜！"
+    },
+    {
+      "type": "entity",
+      "name": "芽精灵",
+      "entity": "mysticalworld:entity_sprout",
+      "scale": 1,
+      "offset": 0,
+      "text": "这些可爱的小植物喜欢在森林里漫步和舞蹈！"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/squid.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/creatures/squid.json
@@ -1,0 +1,22 @@
+{
+  "name": "鱿鱼",
+  "icon": "minecraft:dye:0",
+  "category": "creatures",
+  "pages": [
+    {
+      "type": "animal_spawn_info",
+      "animal": "squid",
+      "breed": "不可繁殖;",
+      "tame": "不可驯服。",
+      "blurb": "用玻璃瓶右键鱿鱼可以获取墨水！"
+    },
+    {
+      "type": "entity",
+      "name": "鱿鱼",
+      "entity": "minecraft:squid",
+      "scale": 0.5,
+      "offset": -0.65,
+      "text": "鱿鱼须可以烤熟了吃！"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/crops/aubergine.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/crops/aubergine.json
@@ -1,0 +1,20 @@
+{
+  "name": "茄子",
+  "icon": "mysticalworld:aubergine",
+  "category": "crops",
+  "pages": [
+    {
+      "type": "spotlight",
+      "link_recipe": true,
+      "item": "mysticalworld:aubergine_seed",
+      "text": "茄子种子可以割草获得。"
+    },
+    {
+      "type": "spotlight",
+      "link_recipe": true,
+      "item": "mysticalworld:aubergine",
+      "text": "成熟之后收割的茄子可以直接吃，也可以用作其他料理的食材！",
+      "title": "茄子作物"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/cuisine/aubergine.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/cuisine/aubergine.json
@@ -1,0 +1,25 @@
+{
+  "name": "Aubergine",
+  "icon": "mysticalworld:aubergine",
+  "category": "cuisine",
+  "pages": [
+    {
+      "type": "spotlight",
+      "link_recipe": true,
+      "item": "mysticalworld:cooked_aubergine",
+      "text": "Aubergine can be harvested from $(l:crops/aubergine)mature aubergine crops$() and used in multiple ways."
+    },
+    {
+      "type": "smelting",
+      "recipe": "mysticalworld:aubergine",
+      "title": "Cooked Aubergine",
+      "text": "Once cooked and with the seeds removed, further additions can be made to the aubergine to make it even tastier!"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:stuffed_aubergine",
+      "title": "Stuffed Aubergine",
+      "text": "A great vegetarian delicacy, the aubergine is combined with beets, carrots & potatoes for a truly magnificent meal!"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/cuisine/suqid.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/cuisine/suqid.json
@@ -1,0 +1,25 @@
+{
+  "name": "鱿鱼",
+  "icon": "mysticalworld:raw_squid",
+  "category": "cuisine",
+  "pages": [
+    {
+      "type": "spotlight",
+      "link_recipe": true,
+      "item": "mysticalworld:raw_squid",
+      "text": "生鱿鱼须可以击杀$(l:creatures/squid)鱿鱼$()获得。可以生吃，也可以烤熟吃。"
+    },
+    {
+      "type": "smelting",
+      "recipe": "mysticalworld:raw_squid",
+      "title": "Calamari",
+      "text": "收集大量的鱿鱼须来制作史诗级的料理，它将带来绝佳的美食体验！"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:epic_squid",
+      "title": "史诗鱿鱼",
+      "text": "史诗鱿鱼散发着不可忽视的紫色光辉！虽然造价很高，但它几乎能恢复全部的饥饿值，并带来奇妙的效果。即使你不饿也可以吃，也能获得效果。"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/cuisine/venison.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/cuisine/venison.json
@@ -1,0 +1,19 @@
+{
+  "name": "鹿肉",
+  "icon": "mysticalworld:cooked_venison",
+  "category": "cuisine",
+  "pages": [
+    {
+      "type": "spotlight",
+      "link_recipe": true,
+      "item": "mysticalworld:venison",
+      "text": "鹿肉可以在$(l:creatures/deer)鹿$()身上取得，用于制作暖心鹿肉料理。"
+    },
+    {
+      "type": "smelting",
+      "recipe": "mysticalworld:venison",
+      "title": "烤鹿肉",
+      "text": "可以烤制生鹿肉获得，也可以从被火焰伤害击杀的鹿身上取得。"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/features/burnt_trees.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/features/burnt_trees.json
@@ -1,0 +1,18 @@
+{
+  "name": "烧焦的树",
+  "icon": "mysticalworld:charred_log",
+  "category": "features",
+  "pages": [
+    {
+      "type": "text",
+      "title": "Charred Tree",
+      "text": "众所周知，大部分树木无法在雷击或野火中幸存。但某些硬木即使树叶焚烧殆尽，树干仍剩余残骸。$(br2)你可以发现这些树木遗留的残骸。"
+    },
+    {
+      "type": "image",
+      "title": "一棵烧焦的树",
+      "text": "$(l:blocks/charred_wood)烧焦的树木$()可以用作装饰。",
+      "images": ["mysticalworld:textures/tree.png"]
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/items/silk_cocoon.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/items/silk_cocoon.json
@@ -1,0 +1,13 @@
+{
+  "name": "蚕茧",
+  "icon": "mysticalworld:silk_cocoon",
+  "category": "items",
+  "pages": [
+    {
+      "type": "spotlight",
+      "item": "mysticalworld:silk_cocoon",
+      "link_recipe": true,
+      "text": "蚕茧是$(l:creatures/silkworm)蚕$()长大以后产生的。把树叶扔在蚕附近喂蚕可以让它长得快。"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/items/silk_thread.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/items/silk_thread.json
@@ -1,0 +1,19 @@
+{
+  "name": "丝线",
+  "icon": "mysticalworld:silk_thread",
+  "category": "items",
+  "pages": [
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:silk_thread",
+      "link_recipe": true,
+      "text": "丝线可以通过处理$(l:items/silk_cocoons)蚕茧$()得到，根据处理方法不同，丝线的产量也不同。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:spindle",
+      "recipe2": "mysticalworld:silk_thread_spindle",
+      "text": "用纺锤处理蚕茧，丝线产量最高;$(br)但纺锤会损耗一些耐久。"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/items/unripe_pearl.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/items/unripe_pearl.json
@@ -1,0 +1,20 @@
+{
+  "name": "不完整的末影珍珠",
+  "icon": "mysticalworld:unripe_pearl",
+  "category": "items",
+  "pages": [
+    {
+      "type": "spotlight",
+      "link_recipe": true,
+      "item": "mysticalworld:unripe_pearl",
+      "text": "不完整的末影珍珠可以从$(l:creatures/endermini)迷你末影人$()身上获得。"
+    },
+    {
+      "type": "crafting",
+      "link_recipe": true,
+      "recipe": "mysticalworld:ender_pearl",
+      "text": "直接使用会将你随机传送。将它们9个合成可以得到完整的末影珍珠。",
+      "title": "Ender Pearl"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/locations/barrows.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/locations/barrows.json
@@ -1,0 +1,18 @@
+{
+  "name": "坟墓",
+  "icon": "minecraft:stonebrick:1",
+  "category": "locations",
+  "pages": [
+    {
+      "type": "text",
+      "title": "坟墓",
+      "text": "曾经埋葬亡灵的地方，如今已经荒废。$(br)你无法确定下面埋藏的是宝藏，还是亡魂。"
+    },
+    {
+      "type": "image",
+      "title": "一座坟墓",
+      "text": "有些值得探索的东西。",
+      "images": ["mysticalworld:textures/barrow.png"]
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/locations/huts.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/locations/huts.json
@@ -1,0 +1,18 @@
+{
+  "name": "小屋",
+  "icon": "mysticalworld:thatch",
+  "category": "locations",
+  "pages": [
+    {
+      "type": "text",
+      "title": "小屋",
+      "text": "你可能会在野外，尤其是平原上发现小屋。$(br)可以作为生存基地，但是要提防地下室里的东西..."
+    },
+    {
+      "type": "image",
+      "title": "野外的小屋",
+      "text": "很适合作为基地。",
+      "images": ["mysticalworld:textures/hut.png"]
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/ores/amethyst.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/ores/amethyst.json
@@ -1,0 +1,37 @@
+{
+  "name": "紫水晶",
+  "icon": "mysticalworld:amethyst_ore",
+  "category": "ores",
+  "flag": "roots:amethyst",
+  "pages": [
+    {
+      "type": "spotlight",
+      "link_recipe": true,
+      "item": "mysticalworld:amethyst_ore",
+      "text": "挖掘紫水晶矿石可以得到紫水晶，，它与钻石一样稀有，用途也类似。"
+    },
+    {
+      "type": "spotlight",
+      "link_recipe": true,
+      "item": "mysticalworld:amethyst_gem",
+      "title": "紫水晶",
+      "text": "紫水晶工具的挖掘等级与钻石工具相同，耐久相近。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:amethyst_axe",
+      "recipe2": "mysticalworld:amethyst_hoe",
+      "title": "紫水晶工具"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:amethyst_knife",
+      "recipe2": "mysticalworld:amethyst_pickaxe"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:amethyst_shovel",
+      "recipe2": "mysticalworld:amethyst_sword"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/ores/copper.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/ores/copper.json
@@ -1,0 +1,37 @@
+{
+  "name": "铜",
+  "icon": "mysticalworld:copper_ore",
+  "category": "ores",
+  "flags": "roots:copper",
+  "pages": [
+    {
+      "type": "spotlight",
+      "link_recipe": true,
+      "item": "mysticalworld:copper_ore",
+      "text": "铜矿石可以在野外几乎任何地方发现。可以熔炼成铜锭用来制作工具。"
+    },
+    {
+      "type": "smelting",
+      "link_recipe": true,
+      "recipe": "mysticalworld:copper_ore",
+      "title": "铜锭",
+      "text": "铜工具和武器的挖掘等级与铁相同。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:copper_axe",
+      "recipe2": "mysticalworld:copper_hoe",
+      "title": "铜工具"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:copper_knife",
+      "recipe2": "mysticalworld:copper_pickaxe"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:copper_shovel",
+      "recipe2": "mysticalworld:copper_sword"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/ores/silver.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/ores/silver.json
@@ -1,0 +1,37 @@
+{
+  "name": "银",
+  "icon": "mysticalworld:silver_ore",
+  "category": "ores",
+  "flags": "roots:silver",
+  "pages": [
+    {
+      "type": "spotlight",
+      "link_recipe": true,
+      "item": "mysticalworld:silver_ore",
+      "text": "银矿石生成在和金矿石类似的高度和位置。可以熔炼成银锭用来制作工具，其附魔能力与金相同，而耐久却稍高。"
+    },
+    {
+      "type": "smelting",
+      "link_recipe": true,
+      "recipe": "mysticalworld:silver_ore",
+      "title": "银锭",
+      "text": "银工具和武器的挖掘等级与金相同。"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:silver_axe",
+      "recipe2": "mysticalworld:silver_hoe",
+      "title": "银工具"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:silver_knife",
+      "recipe2": "mysticalworld:silver_pickaxe"
+    },
+    {
+      "type": "crafting",
+      "recipe": "mysticalworld:silver_shovel",
+      "recipe2": "mysticalworld:silver_sword"
+    }
+  ]
+}

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/templates/animal_spawn_info.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/templates/animal_spawn_info.json
@@ -1,0 +1,77 @@
+{
+  "processor": "epicsquid.mysticalworld.integration.patchouli.api.AnimalSpawnInfo",
+  "components": [
+    {
+      "type": "header",
+      "text": "#title",
+      "x": -1,
+      "y": 0
+    },
+    {
+      "type": "text",
+      "text": "#groupSize",
+      "x": 0,
+      "y": 14
+    },
+    {
+      "type": "text",
+      "text": "#breed",
+      "x": 0,
+      "y": 24
+    },
+    {
+      "type": "text",
+      "text": "#tame",
+      "x": 0,
+      "y": 34
+    },
+    {
+      "type": "text",
+      "text": "#biomes",
+      "x": 0,
+      "y": 44
+    },
+    {
+      "type": "text",
+      "text": "#blurb",
+      "x": 0,
+      "y": 70
+    },
+    {
+      "type": "header",
+      "text": "Drops",
+      "x": -1,
+      "y": 105
+    },
+    {
+      "type": "item",
+      "item": "#item1",
+      "x": 0,
+      "y": 120
+    },
+    {
+      "type": "item",
+      "item": "#item2",
+      "x": 18,
+      "y": 120
+    },
+    {
+      "type": "item",
+      "item": "#item3",
+      "x": 36,
+      "y": 120
+    },
+    {
+      "type": "item",
+      "item": "#item4",
+      "x": 54,
+      "y": 120
+    },
+    {
+      "type": "item",
+      "item": "#item5",
+      "x": 72,
+      "y": 120
+    }
+  ]
+}


### PR DESCRIPTION
除了对mysticalworld模组的lang进行补充外，还对patchouli手册进行了本地化。
经检查，book.json不能通过资源包进行本地化，且patchouli手册当中有一部分内容是无法通过常规方法本地化的。
原因都是这个模组的作者采取了硬编码的方法。
但是这个本地化足以使得绝大部分内容得到很好的本地化，极大地降低玩家的游玩难度。
因此将它提交上来。

- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
