### PR TITLE
更新MysticalWorld模组本地化，使其与官方中文保持一致

### DIFF
--- a/project/assets/mysticalworld/lang/en_us.lang
+++ b/project/assets/mysticalworld/lang/en_us.lang
@@ -1,6 +1,5 @@
 itemGroup.mysticalworld=Mystical World
 
-
 entity.entity_fox.name=Fox
 entity.entity_frog.name=Frog
 entity.entity_beetle.name=Beetle
@@ -11,7 +10,6 @@ entity.entity_owl.name=Owl
 entity.entity_silkworm.name=Silkworm
 entity.entity_lava_cat.name=Lava Cat
 entity.entity_obsidian_cat.name=Obsidian Cat
-
 
 item.carapace.name=Carapace
 item.pelt.name=Pelt
@@ -25,7 +23,6 @@ item.spindle.name=Spindle
 item.silkworm_egg.name=Silkworm Egg
 item.cooked_apple.name=Cooked Apple
 item.pearl.name=Lustrous Pearl
-
 
 # Ingots
 item.copper_ingot.name=Copper Ingot
@@ -41,7 +38,6 @@ item.brass_ingot.name=Brass Ingot
 item.bronze_ingot.name=Bronze Ingot
 item.amethyst_gem.name=Amethyst
 
-
 # Nuggets
 item.copper_nugget.name=Copper Nugget
 item.tin_nugget.name=Tin Nugget
@@ -54,7 +50,6 @@ item.invar_nugget.name=Invar Nugget
 item.electrum_nugget.name=Electrum Nugget
 item.brass_nugget.name=Brass Nugget
 item.bronze_nugget.name=Bronze Nugget
-
 
 # Metal Blocks
 tile.copper_block.name=Block of Copper
@@ -70,7 +65,6 @@ tile.brass_block.name=Block of Brass
 tile.bronze_block.name=Block of Bronze
 tile.amethyst_block.name=Block of Amethyst
 
-
 # Dusts
 item.copper_dust.name=Copper Dust
 item.tin_dust.name=Tin Dust
@@ -84,10 +78,8 @@ item.electrum_dust.name=Electrum Dust
 item.brass_dust.name=Brass Dust
 item.bronze_dust.name=Bronze Dust
 
-
 item.iron_dust.name=Iron Dust
 item.gold_dust.name=Gold Dust
-
 
 # Tiny Dusts
 item.copper_dust_tiny.name=Tiny Pile of Copper Dust
@@ -102,10 +94,8 @@ item.electrum_dust_tiny.name=Tiny Pile of Electrum Dust
 item.brass_dust_tiny.name=Tiny Pile of Brass Dust
 item.bronze_dust_tiny.name=Tiny Pile of Bronze Dust
 
-
 item.iron_dust_tiny.name=Tiny Pile of Iron Dust
 item.gold_dust_tiny.name=Tiny Pile of Gold Dust
-
 
 # Ores
 tile.copper_ore.name=Copper Ore
@@ -116,7 +106,6 @@ tile.nickel_ore.name=Nickel Ore
 tile.aluminum_ore.name=Aluminum Ore
 tile.zinc_ore.name=Zinc Ore
 tile.amethyst_ore.name=Amethyst Ore
-
 
 #Tools
 item.copper_axe.name=Copper Axe
@@ -138,19 +127,15 @@ item.silver_knife.name=Silver Knife
 item.copper_knife.name=Copper Knife
 item.amethyst_knife.name=Amethyst Knife
 
-
 # Embers Metals
 item.dawnstone_ingot.name=Dawnstone Ingot
 item.sooty_iron_ingot.name=Sooty Iron Ingot
 
-
 item.dawnstone_nugget.name=Dawnstone Nugget
 item.sooty_iron_nugget.name=Sooty Iron Nugget
 
-
 tile.dawnstone_block.name=Block of Dawnstone
 tile.sooty_iron_block.name=Block of Sooty Iron
-
 
 # Caminite
 tile.caminite.name=Caminite Block
@@ -159,13 +144,11 @@ tile.caminite_slab.name=Caminite Slab
 tile.caminite_double_slab.name=Caminite Double Slab
 tile.caminite_wall.name=Caminite Wall
 
-
 tile.caminite_bricks.name=Caminite Bricks
 tile.caminite_bricks_stairs.name=Caminite Brick Stairs
 tile.caminite_bricks_slab.name=Caminite Brick Slab
 tile.caminite_bricks_double_slab.name=Caminite Brick Double Slab
 tile.caminite_bricks_wall.name=Caminite Brick Wall
-
 
 # Mud Brick
 tile.wet_mud_brick.name=Wet Mud Brick
@@ -187,7 +170,6 @@ tile.mud_brick_pressure_plate.name=Mud Brick Pressure Plate
 tile.mud_brick_fence.name=Mud Brick Fence
 tile.mud_brick_fence_gate.name=Mud Brick Fence Gate
 
-
 # Charred
 tile.charred_planks.name=Charred Planks
 tile.charred_log.name=Charred Log
@@ -199,7 +181,6 @@ tile.charred_pressure_plate.name=Charred Pressure Plate
 tile.charred_fence.name=Charred Fence
 tile.charred_fence_gate.name=Charred Fence Gate
 
-
 # Pearl
 tile.pearl_block.name=Pearl Block
 tile.pearl_stairs.name=Pearl Stairs
@@ -210,16 +191,11 @@ tile.pearl_pressure_plate.name=Pearl Pressure Plate
 tile.pearl_fence.name=Pearl Fence
 tile.pearl_fence_gate.name=Pearl Fence Gate
 
-
 # Thatch
+tile.thatch.name=Thatch
 tile.thatch_stairs.name=Thatch Stairs
 tile.thatch_slab.name=Thatch Slab
 tile.thatch_wall.name=Thatch Wall
-
-
-# Other Blocks
-tile.thatch.name=Thatch
-
 
 #Solar Infused
 tile.solar_infused_stone.name=Solar Infused Stone
@@ -227,7 +203,6 @@ tile.solar_infused_stone_stairs.name=Solar Infused Stone Stairs
 tile.solar_infused_stone_slab.name=Solar Infused Stone Slab
 tile.solar_infused_stone_double_slab.name=Solar Infused Stone Double Slab
 tile.solar_infused_stone_wall.name=Solar Infused Stone Wall
-
 
 #Advancements
 advancement.mysticalworld.root=Mystical World
@@ -238,7 +213,6 @@ advancement.mysticalworld.aubergine=That's No Carrot...
 advancement.mysticalworld.aubergine.desc=Once, purple carrots were all the rage. But this is an aubergine.
 advancement.mysticalworld.epic_squid=Epic Squid!
 advancement.mysticalworld.epic_squid.desc=Partake in some of the delicious, purple-y goodness of Epic Squid.
-
 
 item.venison.name=Venison
 item.cooked_venison.name=Cooked Venison
@@ -251,9 +225,7 @@ item.stuffed_aubergine.name=Stuffed Aubergine
 item.assorted_seeds.name=Mixed Seeds
 item.cooked_seeds.name=Toasted Seeds
 
-
 message.squid.cooldown=Give it time to produce more ink!
-
 
 # Sounds
 mysticalworld.subtitles.entity.fox.aggro=Fox yips
@@ -289,7 +261,6 @@ mysticalworld.subtitles.entity.silkworm.hurt=Silkworm hurt
 mysticalworld.subtitles.entity.silkworm.step=Silkworm walks
 mysticalworld.subtitles.entity.silkworm.eat=Silkworm eats
 
-
 # Tags
 forge.biome.tags.hot.name=Hot
 forge.biome.tags.cold.name=Cold
@@ -324,8 +295,9 @@ forge.biome.tags.beach.name=Beach
 forge.biome.tags.void.name=Void
 forge.biome.tags.default.name=Default
 
-
 # Patchouli integration
+mysticalworld.guidebook.name=Encyclopædia Mysticum
+mysticalworld.guidebook.landing_text=It's a very mysterious world out there! This book will grant you some insight into the many mysterious and mystical things you might come across.
 mysticalworld.patchouli.standard_group=Standard group sizes.
 mysticalworld.patchouli.groups=Groups of %s-%s.
 mysticalworld.patchouli.biomes=Biomes tagged with: %s

--- a/project/assets/mysticalworld/lang/zh_cn.lang
+++ b/project/assets/mysticalworld/lang/zh_cn.lang
@@ -1,4 +1,5 @@
 itemGroup.mysticalworld=魔幻世界
+
 entity.entity_fox.name=狐狸
 entity.entity_frog.name=青蛙
 entity.entity_beetle.name=甲虫
@@ -7,8 +8,9 @@ entity.entity_sprout.name=芽精灵
 entity.entity_endermini.name=迷你末影人
 entity.entity_owl.name=猫头鹰
 entity.entity_silkworm.name=蚕
-entity.entity_lava_cat.name=岩浆豹猫
-entity.entity_obsidian_cat.name=黑曜石豹猫
+entity.entity_lava_cat.name=岩浆猫
+entity.entity_obsidian_cat.name=黑曜石猫
+
 item.carapace.name=甲壳
 item.pelt.name=毛皮
 item.raw_squid.name=生鱿鱼
@@ -20,7 +22,9 @@ item.silk_cocoon.name=蚕茧
 item.spindle.name=纺锤
 item.silkworm_egg.name=蚕卵
 item.cooked_apple.name=熟苹果
-#金属锭
+item.pearl.name=闪耀珍珠
+
+# 金属锭
 item.copper_ingot.name=铜锭
 item.tin_ingot.name=锡锭
 item.silver_ingot.name=银锭
@@ -28,12 +32,13 @@ item.lead_ingot.name=铅锭
 item.nickel_ingot.name=镍锭
 item.aluminum_ingot.name=铝锭
 item.zinc_ingot.name=锌锭
-item.invar_ingot.name=因瓦合金锭
+item.invar_ingot.name=殷钢锭
 item.electrum_ingot.name=琥珀金锭
 item.brass_ingot.name=黄铜锭
 item.bronze_ingot.name=青铜锭
 item.amethyst_gem.name=紫水晶
-#金属粒
+
+# 金属粒
 item.copper_nugget.name=铜粒
 item.tin_nugget.name=锡粒
 item.silver_nugget.name=银粒
@@ -41,11 +46,12 @@ item.lead_nugget.name=铅粒
 item.nickel_nugget.name=镍粒
 item.aluminum_nugget.name=铝粒
 item.zinc_nugget.name=锌粒
-item.invar_nugget.name=因瓦合金粒
+item.invar_nugget.name=殷钢粒
 item.electrum_nugget.name=琥珀金粒
 item.brass_nugget.name=黄铜粒
 item.bronze_nugget.name=青铜粒
-# Metal 块s
+
+# 金属块
 tile.copper_block.name=铜块
 tile.tin_block.name=锡块
 tile.silver_block.name=银块
@@ -53,26 +59,29 @@ tile.lead_block.name=铅块
 tile.nickel_block.name=镍块
 tile.aluminum_block.name=铝块
 tile.zinc_block.name=锌块
-tile.invar_block.name=因瓦合金块
+tile.invar_block.name=殷钢块
 tile.electrum_block.name=琥珀金块
 tile.brass_block.name=黄铜块
 tile.bronze_block.name=青铜块
 tile.amethyst_block.name=紫水晶块
-#粉s
+
+# 金属粉
 item.copper_dust.name=铜粉
 item.tin_dust.name=锡粉
 item.silver_dust.name=银粉
 item.lead_dust.name=铅粉
 item.nickel_dust.name=镍粉
-item.aluminum_dust.name=Aluminum粉
+item.aluminum_dust.name=铝粉
 item.zinc_dust.name=锌粉
-item.invar_dust.name=因瓦合金粉
+item.invar_dust.name=殷钢粉
 item.electrum_dust.name=琥珀金粉
 item.brass_dust.name=黄铜粉
 item.bronze_dust.name=青铜粉
+
 item.iron_dust.name=铁粉
 item.gold_dust.name=金粉
-# 锡y粉s
+
+# 小堆粉
 item.copper_dust_tiny.name=小堆铜粉
 item.tin_dust_tiny.name=小堆锡粉
 item.silver_dust_tiny.name=小堆银粉
@@ -80,22 +89,25 @@ item.lead_dust_tiny.name=小堆铅粉
 item.nickel_dust_tiny.name=小堆镍粉
 item.aluminum_dust_tiny.name=小堆铝粉
 item.zinc_dust_tiny.name=小堆锌粉
-item.invar_dust_tiny.name=小堆因瓦合金粉
+item.invar_dust_tiny.name=小堆殷钢粉
 item.electrum_dust_tiny.name=小堆琥珀金粉
 item.brass_dust_tiny.name=小堆黄铜粉
 item.bronze_dust_tiny.name=小堆青铜粉
+
 item.iron_dust_tiny.name=小堆铁粉
 item.gold_dust_tiny.name=小堆金粉
-#矿石s
+
+# 矿石
 tile.copper_ore.name=铜矿石
 tile.tin_ore.name=锡矿石
 tile.silver_ore.name=银矿石
 tile.lead_ore.name=铅矿石
 tile.nickel_ore.name=镍矿石
-tile.aluminum_ore.name=Aluminum矿石
+tile.aluminum_ore.name=铝矿石
 tile.zinc_ore.name=锌矿石
 tile.amethyst_ore.name=紫水晶矿石
-#Tools
+
+# 工具
 item.copper_axe.name=铜斧
 item.silver_axe.name=银斧
 item.amethyst_axe.name=紫水晶斧
@@ -114,25 +126,31 @@ item.amethyst_sword.name=紫水晶剑
 item.silver_knife.name=银匕首
 item.copper_knife.name=铜匕首
 item.amethyst_knife.name=紫水晶匕首
-# Embers Metals
+
+# 余烬材料
 item.dawnstone_ingot.name=黎明石锭
 item.sooty_iron_ingot.name=乌铁锭
+
 item.dawnstone_nugget.name=黎明石粒
 item.sooty_iron_nugget.name=乌铁粒
-tile.dawnstone_block.name=黎明石
-tile.sooty_iron_block.name=乌铁
+
+tile.dawnstone_block.name=黎明石块
+tile.sooty_iron_block.name=乌铁块
+
 # 方镁矾
 tile.caminite.name=方镁矾块
 tile.caminite_stairs.name=方镁矾楼梯
 tile.caminite_slab.name=方镁矾台阶
 tile.caminite_double_slab.name=方镁矾双台阶
 tile.caminite_wall.name=方镁矾墙
+
 tile.caminite_bricks.name=方镁矾砖
 tile.caminite_bricks_stairs.name=方镁矾砖楼梯
 tile.caminite_bricks_slab.name=方镁矾砖台阶
 tile.caminite_bricks_double_slab.name=方镁矾砖双台阶
 tile.caminite_bricks_wall.name=方镁矾砖墙
-# 泥块
+
+# 泥砖
 tile.wet_mud_brick.name=湿润的泥砖
 tile.wet_mud_block.name=湿润的泥块
 tile.mud_brick.name=泥砖
@@ -150,7 +168,8 @@ tile.mud_brick_wall.name=泥砖墙
 tile.mud_brick_button.name=泥砖按钮
 tile.mud_brick_pressure_plate.name=泥砖压力板
 tile.mud_brick_fence.name=泥砖栅栏
-tile.mud_brick_fence_gat.ename=泥砖栅栏门
+tile.mud_brick_fence_gate.name=泥砖栅栏门
+
 # 烧焦的方块
 tile.charred_planks.name=烧焦的木板
 tile.charred_log.name=烧焦的原木
@@ -161,66 +180,8 @@ tile.charred_button.name=烧焦的按钮
 tile.charred_pressure_plate.name=烧焦的压力板
 tile.charred_fence.name=烧焦的栅栏
 tile.charred_fence_gate.name=烧焦的栅栏门
-#Solar Infused
-tile.solar_infused_stone.name=太阳能灌注石
-tile.solar_infused_stone_stairs.name=太阳能灌注石楼梯
-tile.solar_infused_stone_slab.name=太阳能灌注石台阶
-tile.solar_infused_stone_double_slab.name=太阳能灌注石双台阶
-tile.solar_infused_stone_wall.name=太阳能灌注石墙
-#Advancements
-advancement.mysticalworld.root=魔幻世界
-advancement.mysticalworld.root.desc=呼吸来自全新魔幻世界的空气！
-advancement.mysticalworld.amethyst=你醉了吗？
-advancement.mysticalworld.amethyst.desc=挖到一块比钻石更珍贵的紫水晶
-advancement.mysticalworld.aubergine=比胡萝卜好
-advancement.mysticalworld.aubergine.desc=紫色的萝卜曾风靡一时，但这是茄子
-advancement.mysticalworld.epic_squid=史诗鱿鱼！
-advancement.mysticalworld.epic_squid.desc=吃一口神奇的史诗鱿鱼
-item.venison.name=鹿肉
-item.cooked_venison.name=烤鹿肉
-item.antlers.name=鹿角
-item.ink_bottle.name=墨水瓶
-item.aubergine_seed.name=茄子种子
-item.aubergine.name=茄子
-item.cooked_aubergine.name=烤茄子
-item.stuffed_aubergine.name=酿茄子
-message.squid.cooldown=鱿鱼还没有产生足够的墨水！
-# Sounds
-mysticalworld.subtitles.entity.fox.aggro=狐狸:啸叫
-mysticalworld.subtitles.entity.fox.bark=狐狸:吼叫
-mysticalworld.subtitles.entity.fox.bite=狐狸:撕咬
-mysticalworld.subtitles.entity.fox.death=狐狸:死亡
-mysticalworld.subtitles.entity.fox.eat=狐狸:吞食
-mysticalworld.subtitles.entity.fox.idle=狐狸:漫步
-mysticalworld.subtitles.entity.fox.sleep=狐狸:睡眠
-mysticalworld.subtitles.entity.fox.sniff=狐狸:抽鼻
-mysticalworld.subtitles.entity.fox.spit=狐狸:吐东西
-mysticalworld.subtitles.entity.sprout.ambient=芽精灵:漫步
-mysticalworld.subtitles.entity.endermini.death=迷你末影人:死亡
-mysticalworld.subtitles.entity.endermini.hit=迷你末影人:受伤
-mysticalworld.subtitles.entity.endermini.idle=迷你末影人:低语
-mysticalworld.subtitles.entity.endermini.portal=迷你末影人:传送
-mysticalworld.subtitles.entity.endermini.scream=迷你末影人:尖叫
-mysticalworld.subtitles.entity.endermini.stare=迷你末影人:愤怒
-mysticalworld.subtitles.entity.silkworm.egg.use=蚕卵:破壳
-mysticalworld.subtitles.entity.lava_cat.sizzle=岩浆豹猫:嘶嘶声
-mysticalworld.subtitles.entity.frog.slime=青蛙:吐出粘液
-mysticalworld.subtitles.entity.lava_cat.ambient=岩浆豹猫:喵喵
-mysticalworld.subtitles.entity.lava_cat.death=岩浆豹猫:死亡
-mysticalworld.subtitles.entity.lava_cat.受伤=岩浆豹猫:受伤
-mysticalworld.subtitles.entity.lava_cat.purr=岩浆豹猫:呼噜
-mysticalworld.subtitles.entity.lava_cat.purreow=岩浆豹猫:呼噜
-mysticalworld.subtitles.entity.silkworm.plop=蚕:成长
-mysticalworld.subtitles.entity.squid.milk=鱿鱼:喷墨
-mysticalworld.subtitles.item.unripe_pearl.use=不完整的末影珍珠:传送
-mysticalworld.subtitles.entity.silkworm.ambient=蚕:吱吱
-mysticalworld.subtitles.entity.silkworm.death=蚕:死亡
-mysticalworld.subtitles.entity.silkworm.受伤=蚕:受伤
-mysticalworld.subtitles.entity.silkworm.step=蚕:漫步
-mysticalworld.subtitles.entity.silkworm.eat=蚕:进食
-item.pearl.name=光泽珍珠
-tile.mud_brick_fence_gate.name=泥砖栅栏门
-# Pearl
+
+# 珍珠
 tile.pearl_block.name=珍珠块
 tile.pearl_stairs.name=珍珠楼梯
 tile.pearl_slab.name=珍珠台阶
@@ -229,29 +190,90 @@ tile.pearl_button.name=珍珠按钮
 tile.pearl_pressure_plate.name=珍珠压力板
 tile.pearl_fence.name=珍珠栅栏
 tile.pearl_fence_gate.name=珍珠栅栏门
-# Thatch
+
+# 茅草
+tile.thatch.name=茅草
 tile.thatch_stairs.name=茅草楼梯
 tile.thatch_slab.name=茅草台阶
 tile.thatch_wall.name=茅草墙
-# Other Blocks
-tile.thatch.name=茅草
+
+# 太阳能灌注石
+tile.solar_infused_stone.name=太阳能灌注石
+tile.solar_infused_stone_stairs.name=太阳能灌注石楼梯
+tile.solar_infused_stone_slab.name=太阳能灌注石台阶
+tile.solar_infused_stone_double_slab.name=太阳能灌注石双台阶
+tile.solar_infused_stone_wall.name=太阳能灌注石墙
+
+# 成就
+advancement.root=魔幻世界
+advancement.root.desc=呼吸来自全新魔幻世界的空气！
+advancement.amethyst=你醉了吗？
+advancement.amethyst.desc=挖到一块比钻石更珍贵的紫水晶
+advancement.aubergine=比胡萝卜好
+advancement.aubergine.desc=紫色的萝卜曾风靡一时，但这是茄子
+advancement.epic_squid=史诗鱿鱼！
+advancement.epic_squid.desc=吃一口神奇的史诗鱿鱼
+
+item.venison.name=鹿肉
+item.cooked_venison.name=烤鹿肉
+item.antlers.name=鹿角
+item.ink_bottle.name=墨水瓶
+item.aubergine_seed.name=茄子种子
+item.aubergine.name=茄子
+item.cooked_aubergine.name=烤茄子
+item.stuffed_aubergine.name=酿茄子
 item.assorted_seeds.name=混合种子
-item.cooked_seeds.name=烘焙种子
-mysticalworld.subtitles.entity.lava_cat.hurt=岩浆豹猫:受伤
-mysticalworld.subtitles.entity.silkworm.hurt=蚕:受伤
+item.cooked_seeds.name=烤种子
+
+message.squid.cooldown=鱿鱼还没有产生出足够的墨水！
+
+# 音效
+mysticalworld.subtitles.entity.fox.aggro=狐狸：啸叫
+mysticalworld.subtitles.entity.fox.bark=狐狸：吼叫
+mysticalworld.subtitles.entity.fox.bite=狐狸：撕咬
+mysticalworld.subtitles.entity.fox.death=狐狸：死亡
+mysticalworld.subtitles.entity.fox.eat=狐狸：吞食
+mysticalworld.subtitles.entity.fox.idle=狐狸：漫步
+mysticalworld.subtitles.entity.fox.sleep=狐狸：睡眠
+mysticalworld.subtitles.entity.fox.sniff=狐狸：抽鼻
+mysticalworld.subtitles.entity.fox.spit=狐狸：吐东西
+mysticalworld.subtitles.entity.sprout.ambient=芽精灵：漫步
+mysticalworld.subtitles.entity.endermini.death=迷你末影人：死亡
+mysticalworld.subtitles.entity.endermini.hit=迷你末影人：受伤
+mysticalworld.subtitles.entity.endermini.idle=迷你末影人：低语
+mysticalworld.subtitles.entity.endermini.portal=迷你末影人：传送
+mysticalworld.subtitles.entity.endermini.scream=迷你末影人：尖叫
+mysticalworld.subtitles.entity.endermini.stare=迷你末影人：愤怒
+mysticalworld.subtitles.entity.silkworm.egg.use=蚕卵：破壳
+mysticalworld.subtitles.entity.lava_cat.sizzle=岩浆猫：嘶嘶声
+mysticalworld.subtitles.entity.frog.slime=青蛙：吐出粘液
+mysticalworld.subtitles.entity.lava_cat.ambient=岩浆猫：喵喵
+mysticalworld.subtitles.entity.lava_cat.death=岩浆猫：死亡
+mysticalworld.subtitles.entity.lava_cat.hurt=岩浆猫：受伤
+mysticalworld.subtitles.entity.lava_cat.purr=岩浆猫：呼噜
+mysticalworld.subtitles.entity.lava_cat.purreow=岩浆猫：呼噜
+mysticalworld.subtitles.entity.silkworm.plop=蚕：成长
+mysticalworld.subtitles.entity.squid.milk=鱿鱼：喷墨
+mysticalworld.subtitles.item.unripe_pearl.use=不完整的末影珍珠：传送
+mysticalworld.subtitles.entity.silkworm.ambient=蚕：吱吱
+mysticalworld.subtitles.entity.silkworm.death=蚕：死亡
+mysticalworld.subtitles.entity.silkworm.hurt=蚕：受伤
+mysticalworld.subtitles.entity.silkworm.step=蚕：漫步
+mysticalworld.subtitles.entity.silkworm.eat=蚕：进食
+
 # Tags
 forge.biome.tags.hot.name=炎热
 forge.biome.tags.cold.name=寒冷
-forge.biome.tags.sparse.name=贫瘠
-forge.biome.tags.dense.name=繁茂
+forge.biome.tags.sparse.name=稀疏
+forge.biome.tags.dense.name=茂密
 forge.biome.tags.wet.name=湿润
 forge.biome.tags.dry.name=干燥
 forge.biome.tags.savanna.name=热带草原
-forge.biome.tags.coniferous.name=针叶
+forge.biome.tags.coniferous.name=针叶林
 forge.biome.tags.jungle.name=丛林
-forge.biome.tags.spooky.name=阴森
-forge.biome.tags.dead.name=荒死
-forge.biome.tags.lush.name=葱郁
+forge.biome.tags.spooky.name=诡异
+forge.biome.tags.dead.name=死寂
+forge.biome.tags.lush.name=葱翠
 forge.biome.tags.nether.name=下界
 forge.biome.tags.end.name=末地
 forge.biome.tags.mushroom.name=蘑菇
@@ -259,17 +281,23 @@ forge.biome.tags.magical.name=魔幻
 forge.biome.tags.rare.name=稀有
 forge.biome.tags.ocean.name=海洋
 forge.biome.tags.river.name=河流
-forge.biome.tags.water.name=水系
+forge.biome.tags.water.name=水域
 forge.biome.tags.mesa.name=平顶山
 forge.biome.tags.forest.name=森林
 forge.biome.tags.plains.name=平原
-forge.biome.tags.mountain.name=高山
-forge.biome.tags.hills.name=山丘
+forge.biome.tags.mountain.name=山地
+forge.biome.tags.hills.name=丘陵
 forge.biome.tags.swamp.name=沼泽
-forge.biome.tags.sandy.name=沙漠
-forge.biome.tags.snowy.name=雪原
-forge.biome.tags.wasteland.name=废土
+forge.biome.tags.sandy.name=沙地
+forge.biome.tags.snowy.name=积雪
+forge.biome.tags.wasteland.name=荒漠
 forge.biome.tags.beach.name=海滩
 forge.biome.tags.void.name=虚空
 forge.biome.tags.default.name=默认
-mysticalworld.patchouli.biomes=群系被标记为：%s
+
+# Patchouli integration
+mysticalworld.guidebook.name=魔幻世界漫游记
+mysticalworld.guidebook.landing_text=这是一个美丽的魔法世界！$(br2)这本书将介绍$(br)$(l)奇妙神秘的魔法事物$()，$(br)给予你必要的引导知识。
+mysticalworld.patchouli.standard_group=常规数量生成。
+mysticalworld.patchouli.groups=%s到%s个一起生成。
+mysticalworld.patchouli.biomes=生成于下列群系：%s

--- a/project/assets/mysticalworld/patchouli_books/world_guide/book.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/book.json
@@ -1,11 +1,11 @@
 {
-	"name": "魔幻世界漫游记",
+	"name": "mysticalworld.guidebook.name",
 	"advancement_namespaces": [
 		"mysticalworld"
 	],
 	"creative_tab": "mysticalworld",
 	"advancements_tab": "mysticalworld",
-	"landing_text": "这是一个美丽的魔法世界！$(br2)这本书将介绍$(br)$(l)奇妙神秘的魔法事物$()，$(br)给予你必要的引导知识。",
+	"landing_text": "mysticalworld.guidebook.landing_text",
 	"book_texture": "mysticalworld:textures/gui/book.png",
 	"filler_texture": "mysticalworld:textures/gui/patchouli/book_filler.png",
 	"model": "mysticalworld:guidebook",

--- a/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/cuisine/toasted_seeds.json
+++ b/project/assets/mysticalworld/patchouli_books/world_guide/zh_cn/entries/cuisine/toasted_seeds.json
@@ -1,0 +1,19 @@
+{
+  "name": "烤种子",
+  "icon": "mysticalworld:cooked_seeds",
+  "category": "cuisine",
+  "pages": [
+    {
+      "type": "crafting",
+      "link_recipe": true,
+      "recipe": "mysticalworld:assorted_seeds",
+      "text": "任意4个种子合成就可以得到混合种子。"
+    },
+    {
+      "type": "smelting",
+      "recipe": "mysticalworld:assorted_seeds",
+      "title": "烤制种子",
+      "text": "用多余的种子就可以制作的简单小零食，在你需要的时候给你补充能量！"
+    }
+  ]
+}


### PR DESCRIPTION
- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)

我在这里提交的中文文本已经被 MysticalWorld 开发组 merge：
https://github.com/MysticMods/MysticalWorld/pull/144

中文文本补充了一个由于 langkey 错误导致的文本缺失（泥砖栅栏门）；
纠正“亮灰荧石粉”为“银粉”；
补足了新版本 Patchouli 手册中添加的内容；
通过修改 book.json 的方法，与开发者协作，彻底消除了手册中的硬编码。

在此提交给中文资源包项目，使得翻译与官方中文保持一致。
