### PR TITLE
[VF]原版修复汉化文件补充

### DIFF
--- a/project/assets/vanillafix/lang/zh_cn.lang
+++ b/project/assets/vanillafix/lang/zh_cn.lang
@@ -1,67 +1,90 @@
+#原版修复
+vanillafix.gui.getLink=获取链接
+vanillafix.gui.failed=[失败]
+vanillafix.gui.keepPlaying=继续游戏
+vanillafix.gui.restart=重启Minecraft
+vanillafix.gui.disabledByConfig=被配置禁用
+
+vanillafix.crashscreen.title=Minecraft崩溃啦！
+vanillafix.crashscreen.summary=Minecraft遇到了一个问题并崩溃了。
+
+vanillafix.crashscreen.paragraph1.line1=下列模组被认为可能是导致崩溃的原因:
+
+vanillafix.crashscreen.unknownCause=未知
+vanillafix.crashscreen.identificationErrored=[鉴别错误，请报告给VanillaFix模组]
+
+vanillafix.crashscreen.paragraph2.line1=单击列表中的任意模组即可访问它们的网站获取技术支持。
+vanillafix.crashscreen.paragraph2.line2=一份报告已经生成，你可以在这里找到（单击）：
+
+vanillafix.crashscreen.reportSaveFailed=[保存报告错误，请查看日志]
+
+vanillafix.crashscreen.paragraph3.line1=单击“获取链接”按钮在你的浏览器中打开它。
+vanillafix.crashscreen.paragraph3.line2=我们建议您将此报告发送给模组的作者以帮助它们修复问题。
+vanillafix.crashscreen.paragraph3.line3=由于安装了VanillaFix，尽管发生了崩溃，你仍然可以继续进行游戏。
+vanillafix.crashscreen.paragraph3.line4= 
+
+vanillafix.initerrorscreen.title=Minecraft未能启动!
+vanillafix.initerrorscreen.summary=启动过程中一个错误阻止了Minecraft的启动
+
+vanillafix.initerrorscreen.paragraph3.line1=点击“获取链接”按钮在你的浏览器中打开它。
+vanillafix.initerrorscreen.paragraph3.line2=我们建议您将此报告发送给模组的作者以帮助它们修复问题。
+vanillafix.initerrorscreen.paragraph3.line3=不幸的是，在发生这个错误之后继续加载Minecraft是不可能的。
+vanillafix.initerrorscreen.paragraph3.line4= 
+
+vanillafix.warnscreen.title=发现潜在问题！
+vanillafix.warnscreen.summary=Minecraft遇到了问题。
+
+vanillafix.warnscreen.paragraph1.line1=这并没有造成崩溃，但是仍有可能导致一些问题，诸如
+vanillafix.warnscreen.paragraph1.line2=世界加载出错、特性失效等等。
+vanillafix.warnscreen.paragraph1.line3=下列模组被认为是可能导致问题的原因:
+
+vanillafix.warnscreen.paragraph3.line1=点击"获取链接"按钮在你的浏览器中打开它。
+vanillafix.warnscreen.paragraph3.line2=我们建议您将此报告发送给模组的作者以帮助他们修复问题。
+vanillafix.warnscreen.paragraph3.line3=您可以继续游戏,但请注意，您稍后可能会遇到一些问题。
+vanillafix.warnscreen.paragraph3.line4=可以在 Mods > VanillaFix > Config > Crashes 中禁用此警告。
+vanillafix.warnscreen.paragraph3.line5= 
+
+vanillafix.notification.title.unknown=发生未知问题!
+vanillafix.notification.title.mod=%s 遇到问题!
+vanillafix.notification.description=按Ctrl + I获取更多信息
+
+vanillafix.fixes=启用/禁用 修复
+vanillafix.fixes.tooltip=控制启用/禁用哪些修复。
 vanillafix.crashes=崩溃选项
-vanillafix.crashes.disableReturnToMainMenu=禁止返回到主菜单
-vanillafix.crashes.disableReturnToMainMenu.tooltip=在崩溃后的屏幕上禁用“返回主菜单”按钮，强制用户在崩溃后关闭游戏。崩溃信息显示屏仍将显示可疑的模组，并能够上传崩溃报告。
-vanillafix.crashes.errorNotificationDuration=错误通知持续时间
-vanillafix.crashes.errorNotificationDuration.tooltip=以毫秒为单位显示错误通知的时间
-vanillafix.crashes.hasteURL=极速 URL
-vanillafix.crashes.hasteURL.tooltip=实例崩溃报告极速上传的 URL，没有末尾的斜杠。
-vanillafix.crashes.problemAction.crash=崩溃
+vanillafix.crashes.tooltip=关于如何处理崩溃的选项
+vanillafix.crashes.disableReturnToMainMenu=禁用“返回主菜单”
+vanillafix.crashes.disableReturnToMainMenu.tooltip=禁用“返回主菜单”按钮，强迫玩家在崩溃后关闭游戏窗口。仍然会显示模组并提供发送崩溃报告的途径。
 vanillafix.crashes.problemAction.log=日志
 vanillafix.crashes.problemAction.notification=通知
-vanillafix.crashes.problemAction.warningScreen=警告屏幕
+vanillafix.crashes.problemAction.warningScreen=屏幕警告
+vanillafix.crashes.problemAction.crash=崩溃
+vanillafix.crashes.scheduledTaskproblemAction=计划任务规划外操作
+vanillafix.crashes.scheduledTaskproblemAction.tooltip=计划任务产生异常时会发生什么
+vanillafix.crashes.errorNotificationDuration=错误通知持续时间
+vanillafix.crashes.errorNotificationDuration.tooltip=错误通知显示的持续时间（单位：毫秒）
 vanillafix.crashes.replaceErrorNotifications=替换错误通知
-vanillafix.crashes.replaceErrorNotifications.tooltip=当连续出现多个错误时，请替换通知而不是顺序出现更多通知
-vanillafix.crashes.scheduledTaskproblemAction=计划任务例外操作
-vanillafix.crashes.scheduledTaskproblemAction.tooltip=计划任务引发异常时应该发生什么
-vanillafix.crashes.tooltip=关于如何处理崩溃的选项
-vanillafix.crashscreen.identificationErrored=[鉴别错误，请报告给 VanillaFix]
-vanillafix.crashscreen.paragraph1.line1=下列的模组被确定为崩溃的可能原因：
-vanillafix.crashscreen.paragraph2.line1=点击列表中的任意模组即可访问它们的网站获取技术支持。
-vanillafix.crashscreen.paragraph2.line2=一份报告已经生成，你可以在这里找到（点击）：
-vanillafix.crashscreen.paragraph3.line1=点击“获取链接”按钮在你的浏览器中打开它。
-vanillafix.crashscreen.paragraph3.line2=我们建议你将此报告发送给模组的作者以帮助它们修复问题。
-vanillafix.crashscreen.paragraph3.line3=由于安装了 VanillaFix，尽管发生了崩溃
-vanillafix.crashscreen.paragraph3.line4=但是你可以继续游戏。
-vanillafix.crashscreen.reportSaveFailed=[保存报告错误，请查看日志]
-vanillafix.crashscreen.summary=Minecraft 遇到一个问题崩溃了。
-vanillafix.crashscreen.title=Minecraft 崩溃啦！
-vanillafix.crashscreen.unknownCause=未知
-vanillafix.debug.switch_profiler.client=使用客户端分析器
-vanillafix.debug.switch_profiler.help=F3 + S = 循环客户端 <-> 集成服务器分析
-vanillafix.debug.switch_profiler.server=使用服务器分析器
-vanillafix.fixes=启用/禁用修复
-vanillafix.fixes.bugFixes=优化与修复原版 BUG
-vanillafix.fixes.bugFixes.tooltip=启用或禁用部分优化与原版 BUG 修复
-vanillafix.fixes.crashFixes=崩溃改进
-vanillafix.fixes.crashFixes.tooltip=启用或禁用崩溃改进（崩溃屏幕，模组识别，崩溃报告格式）。谨记你只能禁用“崩溃选项配置章节”的“回到主菜单”。
+vanillafix.crashes.replaceErrorNotifications.tooltip=当连续出现多个错误时，以下一个错误通知的显示替换上一个的而非顺序出现更多通知
+vanillafix.crashes.hasteURL=Haste URL
+vanillafix.crashes.hasteURL.tooltip=Haste的实例根目录下用于上传崩溃报告的URL（没有末尾的“/”）。# Needs double-check
+vanillafix.fixes.bugFixes=优化和原版问题修复
+vanillafix.fixes.bugFixes.tooltip=启用/禁用优化和原版问题修复
+vanillafix.fixes.crashFixes=崩溃优化
+vanillafix.fixes.crashFixes.tooltip=启用/禁用崩溃优化（屏幕显示，模组显示，崩溃报告的生成等等）。注意：你可以在“崩溃选项”中选择只禁用“返回主菜单”。
 vanillafix.fixes.modSupport=模组支持
-vanillafix.fixes.modSupport.tooltip=启用或禁用一些对其他模组的支持。注：这可能导致一些Mod的动态贴图出现问题。注2：除非因为这个导致崩溃，不然不要随意禁用。
-vanillafix.fixes.profiler=改进型分析
-vanillafix.fixes.profiler.tooltip=启用或禁用改进型分析（Alt + F3 饼图）：分开模组添加的实体和 tile entities，添加 F3 + S 开启的服务器饼图
+vanillafix.fixes.modSupport.tooltip=启用/禁用对其它模组的支持。注意：禁用将破坏部分模组的材质显示，除非这引发了崩溃，否则不要禁用这一选项。
+vanillafix.fixes.profiler=分析器优化
+vanillafix.fixes.profiler.tooltip=启用/禁用分析器优化（Alt + F3的饼图）：分开显示模组添加的实体与“方块实体”（Tile Entity），添加F3 + S的服务器分析器饼图。
 vanillafix.fixes.textureFixes=材质优化
-vanillafix.fixes.textureFixes.tooltip=启用或禁用材质优化。注：这个可以提高 FPS，最好不要关闭。
-vanillafix.fixes.tooltip=控制启用和禁用哪些修复。
-vanillafix.gui.disabledByConfig=配置中禁用
-vanillafix.gui.failed=[失败]
-vanillafix.gui.getLink=获取链接
-vanillafix.gui.keepPlaying=继续游戏
-vanillafix.gui.restart=重启 Minecraft
-vanillafix.initerrorscreen.paragraph3.line1=点击“获取链接”按钮在你的浏览器中打开它。
-vanillafix.initerrorscreen.paragraph3.line2=我们建议你将此报告发送给模组的作者以帮助它们修复问题。
-vanillafix.initerrorscreen.paragraph3.line3=不幸的是，在发生这个错误之后继续
-vanillafix.initerrorscreen.paragraph3.line4=加载 Minecraft 导致了这个错误。
-vanillafix.initerrorscreen.summary=启动过程中一个错误阻止了 Minecraft 的启动
-vanillafix.initerrorscreen.title=Minecraft 未能启动！
-vanillafix.notification.description=按 Ctrl + I 获取更多信息
-vanillafix.notification.title.mod=%s 遇到问题！
-vanillafix.notification.title.unknown=发生未知问题！
-vanillafix.warnscreen.paragraph1.line1=这并没有导致崩溃，但可能仍然存在
-vanillafix.warnscreen.paragraph1.line2=后果：如存档变动或部分功能被破坏。
-vanillafix.warnscreen.paragraph1.line3=下列的模组被确定为崩溃的可能原因：
-vanillafix.warnscreen.paragraph3.line1=点击“获取链接”按钮在你的浏览器中打开它。
-vanillafix.warnscreen.paragraph3.line2=我们建议你将此报告发送给模组作者以帮助它们修复问题。
-vanillafix.warnscreen.paragraph3.line3=你可以继续游戏，但请注意，
-vanillafix.warnscreen.paragraph3.line4=你稍后可能会遇到一些问题
-vanillafix.warnscreen.paragraph3.line5=可以在 模组 > VanillaFix > Config > Crashes 中禁用此警告。
-vanillafix.warnscreen.summary=Minecraft 遇到了问题。
-vanillafix.warnscreen.title=发现潜在问题！
+vanillafix.fixes.textureFixes.tooltip=启用/禁用材质优化。这能够提高游戏时的帧率，因此不建议禁用。
+vanillafix.fixes.blockStates=方块状态优化
+vanillafix.fixes.blockStates.tooltip=启用/禁用方块状态优化。这能够为每个模组减少大约10MB的空间占用，但也可能会与其它模组出现不兼容的情况。
+vanillafix.fixes.dynamicResources=动态资源
+vanillafix.fixes.dynamicResources.tooltip=启用/禁用动态资源。这会禁用初始化时模型、材质与声音的加载，转而在游戏进行时加载它们。这能够减少初始化时超过75%的空间占用，但也可能会与其它模组出现不兼容的情况。
+
+vanillafix.debug.switch_profiler.help=F3 + S切换服务器与客户端分析器
+vanillafix.debug.switch_profiler.server=使用服务器分析器
+vanillafix.debug.switch_profiler.client=使用客户端分析器
+
+vanillafix.debug.draw_texture_map.help=F3 + M启用/禁用地图材质修复覆盖
+vanillafix.debug.draw_texture_map.enabled=启用地图材质覆盖
+vanillafix.debug.draw_texture_map.disabled=禁用地图材质覆盖


### PR DESCRIPTION
从官中自己那份复制来的

- [x] 我已经检查文件路径正确，即 `project/assets/模组id/lang/zh_cn.lang`；
- [x] 我已确定语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已经阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
