### PR TITLE
可怕的箱子汉化

### DIFF
--- a/projects/1.12.2/assets/terrible-chest/terrible_chest/lang/en_us.lang
+++ b/projects/1.12.2/assets/terrible-chest/terrible_chest/lang/en_us.lang
@@ -1,0 +1,12 @@
+tile.terrible_chest.terrible_chest.name=Terrible Chest
+item.terrible_chest.diamond_sphere.name=Diamond Sphere
+container.terrible_chest.terrible_chest=Terrible Chest
+gui.terrible_chest.terrible_chest.count=Count: %,d
+terrible_chest.config.config_title=Terrible Chest Config
+terrible_chest.config.use_itemhandler_capability=Enable ItemHandler capability
+terrible_chest.config.stop_item_collection_and_deliver=Stop item collection and deliver
+terrible_chest.config.maxPageLimit=Maximum page limit
+terrible_chest.config.slotStackLimit=Stack size limit of slot
+tile.terrible_chest.terrible_chest_2.name=Emerald Terrible Chest
+terrible_chest.config.transferStackCount=Stack size that can be transferred at a time
+terrible_chest.config.transferCooldown=Item transfer interval(tick)

--- a/projects/1.12.2/assets/terrible-chest/terrible_chest/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/terrible-chest/terrible_chest/lang/zh_cn.lang
@@ -1,0 +1,12 @@
+tile.terrible_chest.terrible_chest.name=可怕的箱子
+item.terrible_chest.diamond_sphere.name=扩容宝珠
+container.terrible_chest.terrible_chest=可怕的箱子
+gui.terrible_chest.terrible_chest.count=数量: %,d
+terrible_chest.config.config_title=可怕的箱子 - 配置文件
+terrible_chest.config.use_itemhandler_capability=启用ItemHandler兼容
+terrible_chest.config.stop_item_collection_and_deliver=停止物品收集和传输
+terrible_chest.config.maxPageLimit=最大页数
+terrible_chest.config.slotStackLimit=每个插槽的最大容量
+tile.terrible_chest.terrible_chest_2.name=可怕的绿宝石箱子
+terrible_chest.config.transferStackCount=每次可传输的堆栈大小
+terrible_chest.config.transferCooldown=物品传输时间间隔（以tick计）


### PR DESCRIPTION
- [x] 我已确认文件路径、分支均正确：
    - 如果是 1.12 翻译，应该是: `projects/1.12.2/assets/curseforge 域名/模组资源 id/lang/zh_cn.lang`
    - 如果是 1.15-1.16 翻译，应该是: `projects/1.16.1/assets/curseforge 域名/模组资源 id/lang/zh_cn.json`
- [x] 我已确认语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
