### PR TITLE
GTCE副产物JEI支持相关key汉化

### DIFF
--- a/projects/1.12.2/assets/gregtechce/gregtech/lang/en_us.lang
+++ b/projects/1.12.2/assets/gregtechce/gregtech/lang/en_us.lang
@@ -2871,3 +2871,7 @@ gregtech.command.util.hand.material_meta_item=Ore Prefix: %s; Material: %s
 gregtech.command.util.hand.tool_stats=Tool Stats Class: %s
 gregtech.command.util.hand.meta_item=Meta Item Name: %s
 gregtech.command.util.hand.not_a_player=This command is only usable by a player.
+
+gregtech.jei.ore_by_product_from_ore=Use %s for %s
+gregtech.jei.ore_by_product_from_machine=Produce by processing %s with %s
+gregtech.jei.ore_by_product_not_obtainable=Byproduct not obtainable

--- a/projects/1.12.2/assets/gregtechce/gregtech/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/gregtechce/gregtech/lang/zh_cn.lang
@@ -2960,3 +2960,7 @@ cover.smart_item_filter.mode.electrolyzer=电解机
 cover.smart_item_filter.mode.centrifuge=离心机
 cover.smart_item_filter.mode.tooltip=安装这个先进物品过滤器的机器，/n它会自动为机械臂提供正确的对应处理物品。
 metaitem.rebreather.name=循环呼吸机
+
+gregtech.jei.ore_by_product_from_ore=在 %s 中处理可获取 %s
+gregtech.jei.ore_by_product_from_machine=由 %s 在 %s 中处理而成
+gregtech.jei.ore_by_product_not_obtainable=该副产物无法获取


### PR DESCRIPTION
- [ ] 我已阅读注意事项 [#847](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/847)
- [ ] 我已确认文件路径、分支均正确：
    - 如果是 1.12 翻译，应该是: `projects/1.12.2/assets/curseforge 域名/模组资源 id/lang/zh_cn.lang`
    - 如果是 1.15-1.16 翻译，应该是: `projects/1.16.1/assets/curseforge 域名/模组资源 id/lang/zh_cn.json`
- [ ] 我已确认语言文件名大小写正确，所有的语言文件全为小写；
- [ ] 我已阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
