### PR TITLE
[R]更新Packer

### DIFF
--- a/config/packer.json
+++ b/config/packer.json
@@ -4,13 +4,12 @@
         "LICENSE",
         "pack.mcmeta",
         "pack.png",
-        "README.md",
-        "assets/1UNKNOWN/minecraft/font/glyph_sizes.bin",
-        "assets/1UNKNOWN/minecraft/texts/end.txt",
-        "assets/1UNKNOWN/minecraft/textures/font/unicode_page_9f.png",
-        "assets/1UNKNOWN/minecraft/textures/font/unicode_page_20.png",
-        "assets/1UNKNOWN/minecraft/textures/font/unicode_page_e9.png"
+        "README.md"
     ],
     "modNameBlackList": [],
-    "domainBlackList": ["minecraft"]
+    "domainBlackList": [],
+    "noProcessNamespace": [
+        "font",
+        "textures"
+    ]
 }

--- a/config/packer.json
+++ b/config/packer.json
@@ -4,8 +4,13 @@
         "LICENSE",
         "pack.mcmeta",
         "pack.png",
-        "README.md"
+        "README.md",
+        "assets/1UNKNOWN/minecraft/font/glyph_sizes.bin",
+        "assets/1UNKNOWN/minecraft/texts/end.txt",
+        "assets/1UNKNOWN/minecraft/textures/font/unicode_page_9f.png",
+        "assets/1UNKNOWN/minecraft/textures/font/unicode_page_20.png",
+        "assets/1UNKNOWN/minecraft/textures/font/unicode_page_e9.png"
     ],
     "modNameBlackList": [],
-    "domainBlackList": []
+    "domainBlackList": ["minecraft"]
 }

--- a/src/Packer/AssetSerializer.cs
+++ b/src/Packer/AssetSerializer.cs
@@ -1,0 +1,89 @@
+﻿using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+
+namespace Packer
+{
+    static class AssetSerializer
+    {
+        public static string Serialize(Dictionary<string, string> assetMap, string extension)
+        {
+            return extension switch
+            {
+                ".json" => JsonSerializer.Serialize<Dictionary<string, string>>(assetMap, new JsonSerializerOptions
+                {
+                    WriteIndented = true
+                }),
+                ".lang" => SerializeFromLang(assetMap),
+                _ => null // 其实不应该执行到这个地方
+            };
+        }
+
+        static string SerializeFromLang(Dictionary<string, string> assetMap)
+        {
+            var sb = new StringBuilder();
+            foreach (var pair in assetMap)
+            {
+                sb.AppendJoin('=', pair.Key, pair.Value);
+                sb.Append(Environment.NewLine);
+            }
+            return sb.ToString();
+        }
+
+        public static Dictionary<string, string> Deserialize(string content, string extension)
+        {
+            return extension switch
+            {
+                ".json" => JsonSerializer.Deserialize<Dictionary<string, string>>(content), // 直接有的算法
+                ".lang" => DeserializeFromLang(content),
+                _ => null // 其实不应该执行到这个地方
+            };
+        }
+
+        static Dictionary<string, string> DeserializeFromLang(string content)
+        {
+            // 下面的 Verbose 仅供调试，不会在 log 里出现
+            // .lang的格式真的乱...
+            Log.Verbose("开始反序列化 .lang 文件");
+            // #PARSE_ESCAPE就算了吧
+            var result = new Dictionary<string, string>();
+            var isInComment = false; // 处理多行注释
+            new List<string>(content.Split(Environment.NewLine,
+                                           StringSplitOptions.RemoveEmptyEntries))
+                .ForEach(line =>
+                {
+                    var isSingleLineComment = false;
+                    new List<string> { "//", "#" }.ForEach(_ => { isSingleLineComment = line.StartsWith(_); });
+                    if (isSingleLineComment)
+                    {
+                        Log.Verbose("跳过了单行注释：{0}", line);
+                    }
+                    else if (isInComment) // 多行注释内
+                    {
+                        Log.Verbose("{0}", line);
+                        if (line.Trim()
+                                   .EndsWith("*/"))
+                        {
+                            isInComment = false;  // 跳出注释
+                        }
+                    }
+                    else if (line.StartsWith("/*")) // 开始多行注释
+                    {
+                        Log.Verbose("跳过了多行注释：{0}", line);
+                    }
+                    else // 真正的条目
+                    {
+                        Log.Verbose("添加对应映射：{0}", line);
+                        var spiltPosition = line.IndexOf('=');
+                        result.Add(line[..(spiltPosition)], line[(spiltPosition + 1)..]);
+                    }
+                }
+            );
+            Log.Verbose("反序列化完成");
+            return result;
+        }
+
+    }
+}

--- a/src/Packer/Config.cs
+++ b/src/Packer/Config.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Packer
@@ -14,9 +12,12 @@ namespace Packer
         public List<string> FilesToInitialize { get; set; }
 
         [JsonPropertyName("modNameBlackList")]
-        public List<String> ModBlackList { get; set; }
+        public List<string> ModBlackList { get; set; }
 
         [JsonPropertyName("domainBlackList")]
-        public List<String> DomainBlackList { get; set; }
+        public List<string> DomainBlackList { get; set; }
+
+        [JsonPropertyName("noProcessNamespace")]
+        public List<string> BypassedNamespace { get; set; }
     }
 }

--- a/src/Packer/Packer.csproj
+++ b/src/Packer/Packer.csproj
@@ -10,8 +10,4 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0-dev-00839" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Formatter\Formatter.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/src/Packer/Program.cs
+++ b/src/Packer/Program.cs
@@ -4,9 +4,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Formatter;
 using static Packer.Utils;
 
 namespace Packer
@@ -19,16 +19,8 @@ namespace Packer
                 .Enrich.FromLogContext()
                 .WriteTo.Console()
                 .CreateLogger();
-            var hashmap = await Util.ReadReplaceFontMap();
+            var mapping = await ReadReplaceFontMap();
             var config = RetrieveConfig();
-            if (config.Version == "1.12.2")
-            {
-                await Util.ReplaceFontInLang(config.Version, hashmap);
-            }
-            else
-            {
-                await Util.ReplaceFontInJson(config.Version, hashmap);
-            }
             Log.Information("开始打包。版本：{0}", config.Version);
             using var stream = File.Create(".\\Minecraft-Mod-Language-Package.zip"); // 生成空 zip 文档
             using var archive = new ZipArchive(stream, ZipArchiveMode.Update);
@@ -64,50 +56,51 @@ namespace Packer
                     continue;
                 }
                 Log.Information("正在打包 {0}（asset-domain：{1}）", name, domain);
-                if (existingDomains.ContainsKey(domain))
+                bool conflict = existingDomains.ContainsKey(domain);
+                if (conflict)
                 {
                     Log.Warning("检测到 asset-domain 与 {0} 重合", existingDomains[domain]);
-                    foreach (var file in asset.assetPath.EnumerateFiles("*", SearchOption.AllDirectories))
+                }
+                foreach (var file in asset.assetPath.EnumerateFiles("*", SearchOption.AllDirectories))
+                {
+                    if (file.FullName.Contains("en_us", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (file.FullName.Contains("en_us", StringComparison.OrdinalIgnoreCase))
-                        {
-                            Log.Information("跳过了英文原文：{0}", file.FullName[(asset.prefixLength + 1)..]);
-                            continue;
-                        }
-                        var destinationPath = $"assets\\{file.FullName[(asset.prefixLength + 1)..]}"
-                            .Replace("zh_CN", "zh_cn") // 修复大小写
-                            .Replace('\\', '/'); // 修复 Java 平台读取 CentralDirectory 部分时正反斜杠的问题
+                        Log.Information("跳过了英文原文：{0}", file.FullName[(asset.prefixLength + 1)..]);
+                        continue;
+                    }
+                    var destinationPath = $"assets\\{file.FullName[(asset.prefixLength + 1)..]}"
+                        .Replace("zh_CN", "zh_cn") // 修复大小写
+                        .Replace('\\', '/'); // 修复 Java 平台读取 CentralDirectory 部分时正反斜杠的问题
+                    var fileContent = File.ReadAllText(file.FullName, Encoding.UTF8)
+                        .Preprocess(file.Extension, mapping);
+
+                    if (conflict)
+                    {
                         var existingFile = archive.GetEntry(destinationPath);
                         if (existingFile is null) // null 代表没有找到文件，也就是该文件没有重合
                         {
-                            archive.CreateEntryFromFile(file.FullName, destinationPath);
+                            archive.CreateLangFile(destinationPath, fileContent);
                             Log.Information("添加了暂未重合的 {0}", destinationPath);
                         }
                         else
                         {
                             Log.Warning("检测到重合文件：{0}", destinationPath);
-                            using var reader = File.OpenRead(file.FullName);
+                            // 如果都传 string 进去，不如顺便把合并系统做成基于 Parse 的，但是有需求了再弄吧
+                            using var reader = new MemoryStream(Encoding.UTF8.GetBytes(fileContent));
                             using var writer = existingFile.Open();
                             CombineLangFiles(writer, reader, file.Extension);
                             Log.Information("完成合并");
+                            
                         }
                     }
-                }
-                else
-                {
-                    foreach (var file in asset.assetPath.EnumerateFiles("*", SearchOption.AllDirectories))
+                    else
                     {
-                        if (file.FullName.Contains("en_us", StringComparison.OrdinalIgnoreCase))
-                        {
-                            Log.Information("跳过了英文原文：{0}", file.FullName[(asset.prefixLength + 1)..]);
-                            continue;
-                        }
-                        var destinationPath = $"assets\\{file.FullName[(asset.prefixLength + 1)..]}"
-                            .Replace("zh_CN", "zh_cn") // 修复大小写
-                            .Replace('\\', '/'); // 修复 Java 平台读取 CentralDirectory 部分时正反斜杠的问题
-                        archive.CreateEntryFromFile(file.FullName, destinationPath);
+                        archive.CreateLangFile(destinationPath, fileContent);
                         Log.Information("添加了 {0}", destinationPath);
                     }
+                }
+                if (!conflict)
+                {
                     Log.Information("向 asset-domain 映射表中加入：{0} -> {1}", domain, name);
                     existingDomains.Add(domain, name);
                 }

--- a/src/Packer/Utils.cs
+++ b/src/Packer/Utils.cs
@@ -1,11 +1,53 @@
 ﻿using Serilog;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace Packer
 {
     static class Utils
     {
+        public static string Preprocess(this string file, string extension, Dictionary<string, string> mappings)
+        { // 不知道需不需要 PostProcess...反正现在即使要写也是一个空方法
+            if (!new List<string> { ".lang", ".json", ".txt" }.Contains(extension))
+            {
+                Log.Warning("检测到未预料到的拓展名：{0}", extension);
+            }
+            foreach (var mapping in mappings)
+            {
+                if (file.Contains(mapping.Key))
+                {
+                    Log.Information("正在进行特殊符号替换：{0} -> {1}", mapping.Key, mapping.Value);
+                }
+                switch (extension)
+                {
+                    case ".lang":
+                    case ".txt":
+                        file.Replace(mapping.Key, Regex.Unescape(mapping.Value));
+                        break;
+                    case ".json":
+                        file.Replace(mapping.Key, mapping.Value);
+                        break;
+                    default:
+                        break;
+                }
+            }
+            return file;
+        }
+
+        public static void CreateLangFile(this ZipArchive archive, string destination, string content)
+        {
+            using var writer = new StreamWriter(
+                archive.CreateEntry(destination)
+                       .Open(),
+                Encoding.UTF8);
+            writer.Write(content);
+            writer.Flush(); // 确保一下
+        }
+
         public static void CombineLangFiles(Stream destination, Stream added, string extension)
         {
             // 需要注意的是，不同格式的文件需要不同的处理，因此需要传入拓展名
@@ -45,14 +87,28 @@ namespace Packer
         public static void InitializeArchive(ZipArchive archive, Config config)
         {
             Log.Information("开始初始化压缩包");
-            string commonPrefix = $".\\projects\\{config.Version}";
+            string commonPrefix = $"./projects/{config.Version}";
             config.FilesToInitialize.ForEach(_ =>
             {
-                Log.Information("初始化压缩包：添加 {0}", _);
-                archive.CreateEntryFromFile($"{commonPrefix}\\{_}", _, CompressionLevel.Fastest);
+                var destination = _.Replace("/1UNKNOWN", ""); // 除掉一层文件夹（在 assets/ 里的各种 fix）
+                Log.Information("初始化压缩包：添加 {0}", _.Replace("/1UNKNOWN",""));
+                archive.CreateEntryFromFile($"{commonPrefix}/{_}", _.Replace("/1UNKNOWN", ""));
             });
 
             Log.Information("初始化完成");
+        }
+
+        public static async Task<Dictionary<string, string>> ReadReplaceFontMap() // 从隔壁弄过来改了一下，就放这里了
+        {
+            var mapping = new Dictionary<string, string>();
+            foreach (string str in await File.ReadAllLinesAsync("./config/fontmap.txt", Encoding.UTF8))
+            {
+                var kv = str.Split('>', 2);
+                var key = kv[0];
+                var value = kv[1];
+                mapping.Add(key, value);
+            }
+            return mapping;
         }
     }
 }

--- a/src/Packer/Utils.cs
+++ b/src/Packer/Utils.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -10,8 +11,10 @@ namespace Packer
 {
     static class Utils
     {
+
         public static string Preprocess(this string file, string extension, Dictionary<string, string> mappings)
         { // 不知道需不需要 PostProcess...反正现在即使要写也是一个空方法
+            // 特殊符号置换
             if (!new List<string> { ".lang", ".json", ".txt" }.Contains(extension))
             {
                 Log.Warning("检测到未预料到的拓展名：{0}", extension);
@@ -25,74 +28,61 @@ namespace Packer
                 switch (extension)
                 {
                     case ".lang":
-                    case ".txt":
-                        file.Replace(mapping.Key, Regex.Unescape(mapping.Value));
+                    case ".txt": // 替换为 unicode 字符
+                        file = file.Replace(mapping.Key, Regex.Unescape(mapping.Value));
                         break;
-                    case ".json":
-                        file.Replace(mapping.Key, mapping.Value);
+                    case ".json": // 替换为 unicode 转义码
+                        file = file.Replace(mapping.Key, mapping.Value);
                         break;
                     default:
                         break;
                 }
+
             }
             return file;
         }
 
-        public static void CreateLangFile(this ZipArchive archive, string destination, string content)
+        public static async Task CreateLangFile(this ZipArchive archive, string destination, string content)
         {
             using var writer = new StreamWriter(
                 archive.CreateEntry(destination)
                        .Open(),
                 Encoding.UTF8);
-            writer.Write(content);
+            await writer.WriteAsync(content);
             writer.Flush(); // 确保一下
         }
 
-        public static void CombineLangFiles(Stream destination, Stream added, string extension)
+        public static string CombineLangFiles(string destination, string added, string extension)
         {
-            // 需要注意的是，不同格式的文件需要不同的处理，因此需要传入拓展名
-            switch (extension)
+            if (!new List<string> { ".json", ".lang" }.Contains(extension))
             {
-                case ".json":
-                    if (destination.Length < 5)
-                    { // 说明目标文件是个空 object，直接把 added 覆盖过去，不需要裁剪
-                        destination.Seek(0, SeekOrigin.Begin); // 确保一下
-                        added.CopyTo(destination);
-                        break;
-                    }
-                    // 在 Json 中，想要合并需要移除源文件最后的花括号（}）
-                    // 值得注意的是，从一个 Stream 的中间开始 Write 会将原 Stream 的后面内容覆盖掉
-                    // 另外的，还需要去掉 2 个 \n\r
-                    // 因此，将目标文件seek到末尾前 2 + 2 + 1 = 5 位才可以把花括号覆盖掉（offset -5）
-                    destination.Seek(-5, SeekOrigin.End);
-                    // 在此之上，还需要一个逗号（,）在条目之间
-                    {   // CS8647  using 变量不能直接在 switch 部分中使用
-                        using var writer = new StreamWriter(destination);
-                        writer.Write(',');
-                        writer.Flush(); // 避免留存在 buffer 中
-                        // 同样的，还需要移除添加文件的开头的花括号（{），通过跳过该字符处理
-                        added.Seek(1, SeekOrigin.Begin);
-                        // 现在可以合并了：
-                        added.CopyTo(destination);
-                    }
-                    break;
-                case ".lang": // 对于 lang，可以直接合并
-                default: // 其他格式也直接合并（出问题的提出来再弄）
-                    destination.Seek(0, SeekOrigin.End);
-                    added.CopyTo(destination);
-                    break;
+                Log.Warning("检测到暂不支持的拓展名（{0}），取消合并", extension);
+                return destination;
             }
+            Log.Information("正在反序列化目标文件");
+            var destMap = AssetSerializer.Deserialize(destination, extension);
+            Log.Information("正在反序列化目标文件");
+            var addMap = AssetSerializer.Deserialize(added, extension);
+            foreach (var pair in addMap)
+            {
+                if (!destMap.TryAdd(pair.Key, pair.Value))
+                {
+                    Log.Warning("检测到相同 key 的条目：{0} -> {1} | {2}，选取 {1}", pair.Key, destMap[pair.Key], pair.Value);
+                }
+            }
+            Log.Information("正在序列化合并后的文件");
+            return AssetSerializer.Serialize(destMap, extension);
         }
 
-        public static void InitializeArchive(ZipArchive archive, Config config)
+        public static void Initialize(this ZipArchive archive, Config config)
         {
             Log.Information("开始初始化压缩包");
             string commonPrefix = $"./projects/{config.Version}";
             config.FilesToInitialize.ForEach(_ =>
             {
                 var destination = _.Replace("/1UNKNOWN", ""); // 除掉一层文件夹（在 assets/ 里的各种 fix）
-                Log.Information("初始化压缩包：添加 {0}", _.Replace("/1UNKNOWN",""));
-                archive.CreateEntryFromFile($"{commonPrefix}/{_}", _.Replace("/1UNKNOWN", ""));
+                Log.Information("初始化压缩包：添加 {0}", destination);
+                archive.CreateEntryFromFile($"{commonPrefix}/{_}", destination);
             });
 
             Log.Information("初始化完成");
@@ -106,9 +96,25 @@ namespace Packer
                 var kv = str.Split('>', 2);
                 var key = kv[0];
                 var value = kv[1];
+                Log.Verbose("添加了映射：{0} -> {1}", key, value);
                 mapping.Add(key, value);
             }
             return mapping;
+        }
+
+        public static bool NeedBypass(this string location, Config config)
+        {
+            foreach (var @namespace in config.BypassedNamespace)
+            {
+                if (location.Contains("/" + @namespace + "/")) return true;
+            }
+            return false;
+        }
+
+        public static Config RetrieveConfig()
+        {
+            var reader = File.ReadAllBytes(".\\config\\packer.json");
+            return JsonSerializer.Deserialize<Config>(reader);
         }
     }
 }


### PR DESCRIPTION
进行了一次重构
还是标上了review，要不然也不会扔到pr去（
看看这样子行不行，需不需要进一步重构
（即使需要也得等到下一周了...我没空

- [x] 我已阅读注意事项 [#847](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/847)
- [x] 我已标记PR以便审查（见`CONTRIBUTING.md`）
- [x] 我已确认文件路径、分支均正确：
    - 如果是 1.12 翻译，应该是: `projects/1.12.2/assets/curseforge 域名/模组资源 id/lang/zh_cn.lang`
    - 如果是 1.15-1.16 翻译，应该是: `projects/1.16.1/assets/curseforge 域名/模组资源 id/lang/zh_cn.json`
- [x] 我已确认语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
