### PR TITLE
[NM] 更新 1.12.2 的 futuremc 和 brewcraft 本地化

### DIFF
--- a/projects/1.12.2/assets/future-mc/futuremc/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/future-mc/futuremc/lang/zh_cn.lang
@@ -7,7 +7,7 @@ tile.futuremc.blast_furnace.name=高炉
 tile.futuremc.smoker.name=烟熏炉
 tile.futuremc.grindstone.name=砂轮
 tile.futuremc.composter.name=堆肥桶
-tile.futuremc.cartography_table=制图台
+tile.futuremc.cartography_table.name=制图台
 
 # Plant
 tile.futuremc.lily_of_the_valley.name=铃兰
@@ -33,8 +33,8 @@ tile.futuremc.diorite_wall.name=闪长岩墙
 tile.futuremc.granite_wall.name=花岗岩墙
 tile.futuremc.prismarine_wall.name=海晶石墙
 tile.futuremc.stone_brick_wall.name=石砖墙
-tile.futuremc.mossy_stone_wall.name=苔石砖墙
-tile.futuremc.end_stone_wall.name=末地石砖墙
+tile.futuremc.mossy_stone_brick_wall.name=苔石砖墙
+tile.futuremc.end_stone_brick_wall.name=末地石砖墙
 tile.futuremc.nether_brick_wall.name=下界砖墙
 tile.futuremc.sandstone_wall.name=砂岩墙
 tile.futuremc.red_sandstone_wall.name=红砂岩墙
@@ -66,6 +66,8 @@ tile.futuremc.honeycomb_block.name=蜜脾块
 
 # Decorative Block
 tile.futuremc.smooth_stone.name=平滑石头
+tile.futuremc.smooth_sandstone.name=平滑砂岩
+tile.futuremc.smooth_red_sandstone.name=平滑红砂岩
 tile.futuremc.smooth_quartz.name=平滑石英
 tile.futuremc.soul_soil.name=灵魂土
 tile.futuremc.fletching_table.name=制箭台
@@ -91,6 +93,9 @@ tile.futuremc.stripped_birch_wood.name=去皮白桦木
 tile.futuremc.stripped_oak_wood.name=去皮橡木
 tile.futuremc.stripped_spruce_wood.name=去皮云杉木
 tile.futuremc.stripped_dark_oak_wood.name=去皮深色橡木
+tile.futuremc.chain.name=锁链
+tile.futuremc.ancient_debris.name=远古残骸
+tile.futuremc.netherite_block.name=下界合金块
 entity.ItemFrame.name=物品展示框
 
 # Banner
@@ -137,6 +142,18 @@ item.futuremc.pufferfish_bucket.name=河豚桶
 item.futuremc.salmon_bucket.name=鲑鱼桶
 item.futuremc.cod_bucket.name=鳕鱼桶
 item.futuremc.tropical_fish_bucket.name=热带鱼桶
+item.futuremc.netherite_axe.name=下界合金斧
+item.futuremc.netherite_hoe.name=下界合金锄
+item.futuremc.netherite_pickaxe.name=下界合金镐
+item.futuremc.netherite_shovel.name=下界合金锹
+item.futuremc.netherite_sword.name=下界合金剑
+item.futuremc.netherite_scrap.name=下界合金碎片
+item.futuremc.netherite_helmet.name=下界合金头盔
+item.futuremc.netherite_chestplate.name=下界合金胸甲
+item.futuremc.netherite_leggings.name=下界合金护腿
+item.futuremc.netherite_boots.name=下界合金靴子
+item.futuremc.netherite_ingot.name=下界合金锭
+item.futuremc.record_pigstep.name=音乐唱片
 
 # GUI
 container.barrel=木桶

--- a/projects/1.12.2/assets/pams-brewcraft/brewcraft/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/pams-brewcraft/brewcraft/lang/zh_cn.lang
@@ -25,6 +25,15 @@ item.tiagapinotnoiritem.name=针叶林黑皮诺葡萄酒
 item.totalvodkaitem.name=完全伏特加
 item.uglyavocadoginitem.name=不好看的牛油果杜松子酒
 
+item.goldschlageritem.name=金箔肉桂酒
+item.blackholewhiskeyitem.name=黑洞威士忌
+item.pointthreeryeitem.name=Point Three黑麦威士忌
+item.ghostpepperabsintheitem.name=幽灵胡椒苦艾酒
+item.borgiaabsintheitem.name=波吉亚苦艾酒
+item.redbeeritem.name=红啤酒
+item.bluebeeritem.name=蓝啤酒
+item.malortitem.name=§ko§r马洛特苦酒§ko§r
+
 item.preparedbeachrummixitem.name=沙滩朗姆酒原浆
 item.preparedcherryvodkamixitem.name=梅子伏特加原浆
 item.preparedcoconutrummixitem.name=椰香朗姆酒原浆
@@ -43,6 +52,15 @@ item.preparedswampmerlotmixitem.name=沼泽梅洛红葡萄酒原浆
 item.preparedtiagapinotnoirmixitem.name=针叶林黑皮诺葡萄酒原浆
 item.preparedtotalvodkamixitem.name=完全伏特加原浆
 item.prepareduglyavocadoginmixitem.name=不好看的牛油果杜松子酒原浆
+
+item.preparedgoldschlagermixitem.name=金箔肉桂酒原浆
+item.preparedblackholewhiskeymixitem.name=黑洞威士忌原浆
+item.preparedpointthreeryemixitem.name=Point Three黑麦威士忌原浆
+item.preparedghostpepperabsinthemixitem.name=幽灵胡椒苦艾酒原浆
+item.preparedborgiaabsinthemixitem.name=波吉亚苦艾酒原浆
+item.preparedredbeermixitem.name=红啤酒原浆
+item.preparedbluebeermixitem.name=蓝啤酒原浆
+item.preparedmalortmixitem.name=§ko§r马洛特苦酒§ko§r原浆
 
 item.hopsitem.name=啤酒花
 item.hopsseeditem.name=啤酒花种子


### PR DESCRIPTION
- [x] 我已阅读注意事项 [#847](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/847)
- [x] 我已标记PR以便审查（见`CONTRIBUTING.md`）
- [x] 我已确认文件路径、分支均正确：
    - 是 1.12 翻译，路径是: `projects/1.12.2/assets/curseforge 域名/模组资源 id/lang/zh_cn.lang`
- [X] 我已确认语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
