### PR TITLE
[NR][1.16]添加 ZeroCore2 汉化文件

### DIFF
--- a/projects/1.16.1/assets/zerocore/zerocore/lang/en_us.json
+++ b/projects/1.16.1/assets/zerocore/zerocore/lang/en_us.json
@@ -1,0 +1,26 @@
+{
+    "_comment": "zerocore lang file",
+    "_comment": "API - multiblock",
+    "zerocore:api.multiblock.validation.success": "Machine validation was successful.",
+    "zerocore:api.multiblock.validation.block_not_connected": "The block is not connected to a multiblock controller.",
+    "zerocore:api.multiblock.validation.too_few_parts": "Machine is too small.",
+    "zerocore:api.multiblock.validation.machine_too_large": "Machine is too large, it may be at most %1$d blocks in the %2$s dimension.",
+    "zerocore:api.multiblock.validation.machine_too_small": "Machine is too small, it must be at least %1$d blocks in the %2$s dimension.",
+    "zerocore:api.multiblock.validation.invalid_part": "Part is incompatible with this machine",
+    "zerocore:api.multiblock.validation.invalid_part_for_frame": "Block is not valid for use in the machine's frame",
+    "zerocore:api.multiblock.validation.invalid_part_for_bottom": "Block is not valid for use in the machine's bottom layer",
+    "zerocore:api.multiblock.validation.invalid_part_for_top": "Block is not valid for use in the machine's top layer",
+    "zerocore:api.multiblock.validation.invalid_part_for_sides": "Block is not valid for use in the machine's sides",
+    "zerocore:api.multiblock.validation.invalid_part_for_interior": "Block is not valid for use in the machine's interior",
+    "zerocore:api.multiblock.validation.invalid_foreign_part": "Block belong to another machine",
+
+    "_comment": "Items",
+    "item.zerocore.debugtool": "Debug Tool",
+    "zerocore:debugTool.block.tooltip1": "Right-click a block to show debug info",
+    "zerocore:debugTool.block.tooltip2": "%1$sQueries are performed on the server side by default",
+    "zerocore:debugTool.block.tooltip3": "%1$sSneak: %2$squery on the client side",
+
+    "_comment": "Miscellanea",
+    "zerocore:gui.patchouli.missing": "The mod Patchouli need to be installed to use this feature",
+    "zerocore:gui.manual.open": "Open the manual page"
+}

--- a/projects/1.16.1/assets/zerocore/zerocore/lang/zh_cn.json
+++ b/projects/1.16.1/assets/zerocore/zerocore/lang/zh_cn.json
@@ -1,0 +1,20 @@
+{
+    "zerocore:api.multiblock.validation.success": "机器已生效",
+    "zerocore:api.multiblock.validation.block_not_connected": "该方块没有与控制器相连",
+    "zerocore:api.multiblock.validation.too_few_parts": "机器太小",
+    "zerocore:api.multiblock.validation.machine_too_large": "机器太大，在 %2$s 轴最多有 %1$d 个方块",
+    "zerocore:api.multiblock.validation.machine_too_small": "机器太小，在 %2$s 轴最少有 %1$d 个方块",
+    "zerocore:api.multiblock.validation.invalid_part": "该组件与机器不兼容",
+    "zerocore:api.multiblock.validation.invalid_part_for_frame": "该方块不允许在机器框架上使用",
+    "zerocore:api.multiblock.validation.invalid_part_for_bottom": "该方块不允许在机器底面使用",
+    "zerocore:api.multiblock.validation.invalid_part_for_top": "该方块不允许在机器顶面使用",
+    "zerocore:api.multiblock.validation.invalid_part_for_sides": "该方块不允许在机器侧面使用",
+    "zerocore:api.multiblock.validation.invalid_part_for_interior": "该方块不允许在机器内部使用",
+    "zerocore:api.multiblock.validation.invalid_foreign_part": "该方块属于另一台机器",
+    "item.zerocore.debugtool": "调试工具",
+    "zerocore:debugTool.block.tooltip1": "右击方块显示调试信息",
+    "zerocore:debugTool.block.tooltip2": "%1$s默认在服务器端查询",
+    "zerocore:debugTool.block.tooltip3": "%1$s潜行：%2$s在客户端查询",
+    "zerocore:gui.patchouli.missing": "使用该功能需要安装 Patchouli 模组",
+    "zerocore:gui.manual.open": "打开手册页面"
+}


### PR DESCRIPTION
- [x] 我已阅读注意事项 [#847](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/847)
- [x] 我已标记PR以便审查（见`CONTRIBUTING.md`）
- [x] 我已确认文件路径、分支均正确：
    - 如果是 1.12 翻译，应该是: `projects/1.12.2/assets/curseforge 域名/模组资源 id/lang/zh_cn.lang`
    - 如果是 1.15-1.16 翻译，应该是: `projects/1.16.1/assets/curseforge 域名/模组资源 id/lang/zh_cn.json`
- [x] 我已确认语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
