### PR TITLE
[NR][1.16] 添加 Construction Wand 翻译文件

### DIFF
--- a/projects/1.16.1/assets/construction-wand/constructionwand/lang/zh_cn.json
+++ b/projects/1.16.1/assets/construction-wand/constructionwand/lang/zh_cn.json
@@ -1,1 +1,55 @@
-{}
+{
+    "item.constructionwand.stone_wand": "石制手杖",
+    "item.constructionwand.iron_wand": "铁制手杖",
+    "item.constructionwand.diamond_wand": "钻石手杖",
+    "item.constructionwand.infinity_wand": "无尽手杖",
+
+    "constructionwand.tooltip.blocks": "最多放置 %d 个方块",
+    "constructionwand.tooltip.shift": "按住 [SHIFT]",
+
+    "constructionwand.option.mode": "",
+    "constructionwand.option.mode.default": "默认模式",
+    "constructionwand.option.mode.default.desc": "在面向您的一侧放置方块",
+    "constructionwand.option.mode.angel": "§6天使模式",
+    "constructionwand.option.mode.angel.desc": "在方块的背面放置，还可以悬空放置方块",
+
+    "constructionwand.option.lock": "锁定： ",
+    "constructionwand.option.lock.horizontal": "§a左 / 右",
+    "constructionwand.option.lock.horizontal.desc": "在起始方块的前面延伸一行水平方块",
+    "constructionwand.option.lock.vertical": "§a上 / 下",
+    "constructionwand.option.lock.vertical.desc": "在起始方块的前面延伸一列垂直方块",
+    "constructionwand.option.lock.northsouth": "§6南 / 北",
+    "constructionwand.option.lock.northsouth.desc": "在起始方块的上面，向南 / 北方向延伸一行",
+    "constructionwand.option.lock.eastwest": "§6东 / 西",
+    "constructionwand.option.lock.eastwest.desc": "在起始方块的上面，向东 / 西方向延伸一行",
+    "constructionwand.option.lock.nolock": "§c无",
+    "constructionwand.option.lock.nolock.desc": "从起始方块向任意一面延伸",
+
+    "constructionwand.option.direction": "方向： ",
+    "constructionwand.option.direction.target": "§6目标",
+    "constructionwand.option.direction.target.desc": "放置的方块方向与目标方块的方向相同",
+    "constructionwand.option.direction.player": "§a玩家",
+    "constructionwand.option.direction.player.desc": "放置的方块面向玩家",
+
+    "constructionwand.option.replace": "替换：",
+    "constructionwand.option.replace.yes": "§a是",
+    "constructionwand.option.replace.yes.desc": "替换某些方块，例如流体、雪、高草丛",
+    "constructionwand.option.replace.no": "§c否",
+    "constructionwand.option.replace.no.desc": "不替换方块",
+
+    "constructionwand.option.match": "匹配： ",
+    "constructionwand.option.match.exact": "§a精确",
+    "constructionwand.option.match.exact.desc": "只延伸完全相同的方块",
+    "constructionwand.option.match.similar": "§6模糊",
+    "constructionwand.option.match.similar.desc": "相似的方块被认为是相同的（草方块 / 泥土类型）",
+    "constructionwand.option.match.any": "§c任意",
+    "constructionwand.option.match.any.desc": "延伸任意方块",
+
+    "constructionwand.option.random": "随机： ",
+    "constructionwand.option.random.yes": "§a是",
+    "constructionwand.option.random.yes.desc": "随机放置快捷栏中的方块",
+    "constructionwand.option.random.no": "§c否",
+    "constructionwand.option.random.no.desc": "不会随机放置方块",
+
+    "stat.constructionwand.use_wand": "放置方块需要使用手杖"
+}

--- a/projects/1.16.1/assets/construction-wand/constructionwand/lang/zh_cn.json
+++ b/projects/1.16.1/assets/construction-wand/constructionwand/lang/zh_cn.json
@@ -39,11 +39,11 @@
 
     "constructionwand.option.match": "匹配： ",
     "constructionwand.option.match.exact": "§a精确",
-    "constructionwand.option.match.exact.desc": "只延伸完全相同的方块",
+    "constructionwand.option.match.exact.desc": "只放置完全相同的方块",
     "constructionwand.option.match.similar": "§6模糊",
     "constructionwand.option.match.similar.desc": "相似的方块被认为是相同的（草方块 / 泥土类型）",
     "constructionwand.option.match.any": "§c任意",
-    "constructionwand.option.match.any.desc": "延伸任意方块",
+    "constructionwand.option.match.any.desc": "放置任意方块",
 
     "constructionwand.option.random": "随机： ",
     "constructionwand.option.random.yes": "§a是",

--- a/projects/1.16.1/assets/construction-wand/constructionwand/lang/zh_cn.json
+++ b/projects/1.16.1/assets/construction-wand/constructionwand/lang/zh_cn.json
@@ -13,7 +13,7 @@
     "constructionwand.option.mode.angel": "§6天使模式",
     "constructionwand.option.mode.angel.desc": "在方块的背面放置，还可以悬空放置方块",
 
-    "constructionwand.option.lock": "锁定： ",
+    "constructionwand.option.lock": "锁定：",
     "constructionwand.option.lock.horizontal": "§a左 / 右",
     "constructionwand.option.lock.horizontal.desc": "在起始方块的前面延伸一行水平方块",
     "constructionwand.option.lock.vertical": "§a上 / 下",
@@ -25,7 +25,7 @@
     "constructionwand.option.lock.nolock": "§c无",
     "constructionwand.option.lock.nolock.desc": "从起始方块向任意一面延伸",
 
-    "constructionwand.option.direction": "方向： ",
+    "constructionwand.option.direction": "方向：",
     "constructionwand.option.direction.target": "§6目标",
     "constructionwand.option.direction.target.desc": "放置的方块方向与目标方块的方向相同",
     "constructionwand.option.direction.player": "§a玩家",
@@ -37,7 +37,7 @@
     "constructionwand.option.replace.no": "§c否",
     "constructionwand.option.replace.no.desc": "不替换方块",
 
-    "constructionwand.option.match": "匹配： ",
+    "constructionwand.option.match": "匹配：",
     "constructionwand.option.match.exact": "§a精确",
     "constructionwand.option.match.exact.desc": "只放置完全相同的方块",
     "constructionwand.option.match.similar": "§6模糊",
@@ -45,7 +45,7 @@
     "constructionwand.option.match.any": "§c任意",
     "constructionwand.option.match.any.desc": "放置任意方块",
 
-    "constructionwand.option.random": "随机： ",
+    "constructionwand.option.random": "随机：",
     "constructionwand.option.random.yes": "§a是",
     "constructionwand.option.random.yes.desc": "随机放置快捷栏中的方块",
     "constructionwand.option.random.no": "§c否",


### PR DESCRIPTION
- [x] 我已阅读注意事项 [#847](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/847)
- [x] 我已标记PR以便审查（见`CONTRIBUTING.md`）
- [x] 我已确认文件路径、分支均正确：
    - 如果是 1.12 翻译，应该是: `projects/1.12.2/assets/curseforge 域名/模组资源 id/lang/zh_cn.lang`
    - 如果是 1.15-1.16 翻译，应该是: `projects/1.16.1/assets/curseforge 域名/模组资源 id/lang/zh_cn.json`
- [x] 我已确认语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
