### PR TITLE
[NR][1.16] 添加 CompactMachines 翻译文件

### DIFF
--- a/projects/1.16.1/assets/compact-machines/compactmachines/lang/en_us.json
+++ b/projects/1.16.1/assets/compact-machines/compactmachines/lang/en_us.json
@@ -1,0 +1,57 @@
+{
+  "itemGroup.compactmachines": "Compact Machines",
+
+  "tooltip.compactmachines.machine_id": "Machine ID: %s",
+  "tooltip.compactmachines.owner": "Owner: %s",
+  "tooltip.compactmachines.unknown_player": "Unknown Player",
+  "tooltip.compactmachines.machine.size": "Size: %1$sx%1$sx%1$s",
+  "tooltip.compactmachines.hold_shift.hint": "Hold shift for details.",
+  "tooltip.compactmachines.psd.hint": "Used as in-game documentation and to enter Compact Machines.",
+  "tooltip.compactmachines.solid_wall.hint": "Warning! Unbreakable for non-creative players!",
+  "tooltip.compactmachines.machine.hint": "A %1$s provides a %2$s room.",
+  "tooltip.compactmachines.tunnel_type": "Type ID: %1$s",
+
+  "messages.compactmachines.psd.spawnpoint_set": "New spawn point set.",
+  "messages.compactmachines.no_machine_data": "No machine data loaded; report this.",
+
+  "block.compactmachines.machine": "Compact Machine",
+  "block.compactmachines.machine_tiny": "Compact Machine (Tiny)",
+  "block.compactmachines.machine_small": "Compact Machine (Small)",
+  "block.compactmachines.machine_normal": "Compact Machine (Normal)",
+  "block.compactmachines.machine_large": "Compact Machine (Large)",
+  "block.compactmachines.machine_giant": "Compact Machine (Giant)",
+  "block.compactmachines.machine_maximum": "Compact Machine (Maximum)",
+
+  "block.compactmachines.solid_wall": "Solid Compact Machine Wall",
+  "block.compactmachines.wall": "Compact Machine Wall",
+  "block.compactmachines.tunnel_wall": "Tunnel",
+
+  "item.compactmachines.machine_tiny": "Compact Machine (Tiny)",
+  "item.compactmachines.machine_small": "Compact Machine (Small)",
+  "item.compactmachines.machine_normal": "Compact Machine (Normal)",
+  "item.compactmachines.machine_large": "Compact Machine (Large)",
+  "item.compactmachines.machine_giant": "Compact Machine (Giant)",
+  "item.compactmachines.machine_maximum": "Compact Machine (Maximum)",
+
+  "item.compactmachines.personal_shrinking_device": "Personal Shrinking Device",
+
+  "item.compactmachines.tunnels.item": "Item Tunnel",
+  "item.compactmachines.tunnels.redstone_in": "Redstone Tunnel (In)",
+  "item.compactmachines.tunnels.redstone_out": "Redstone Tunnel (Out)",
+
+  "compactmachines.cannot_enter": "You fumble with the shrinking device, to no avail. It refuses to work.",
+
+  "compactmachines.connected_block": "Connected: %s",
+  "compactmachines.direction.side": "Side: %s",
+  "compactmachines.direction.up": "Up",
+  "compactmachines.direction.down": "Down",
+  "compactmachines.direction.north": "North",
+  "compactmachines.direction.south": "South",
+  "compactmachines.direction.west": "West",
+  "compactmachines.direction.east": "East",
+
+  "compactmachines.psd.pages.machines.title": "Compact Machines",
+  "compactmachines.psd.pages.machines": "Compact Machines are the core mechanic of this mod. They allow you to build large rooms in a single block space connected to the outside world. They come in various sizes ranging from 3x3x3 to 13x13x13.\n\nYou can use Tunnels to connect the outside block faces with any of the inside walls to transport items, fluids etc.\n\nYou can enter a Compact Machine by right-clicking it with a Personal Shrinking Device. Please use JEI to look up crafting recipes.",
+
+  "compactmachines.errors.unknown_tunnel_type": "Unknown Tunnel Type (%s)"
+}

--- a/projects/1.16.1/assets/compact-machines/compactmachines/lang/zh_cn.json
+++ b/projects/1.16.1/assets/compact-machines/compactmachines/lang/zh_cn.json
@@ -1,0 +1,57 @@
+{
+  "itemGroup.compactmachines": "压缩空间机械",
+
+  "tooltip.compactmachines.machine_id": "机器 ID：%s",
+  "tooltip.compactmachines.owner": "所有者：%s",
+  "tooltip.compactmachines.unknown_player": "未知玩家",
+  "tooltip.compactmachines.machine.size": "尺寸：%1$sx%1$sx%1$s",
+  "tooltip.compactmachines.hold_shift.hint": "按 Shift 查看详细信息。",
+  "tooltip.compactmachines.psd.hint": "该模组的手册，同时也能用于进入压缩空间。",
+  "tooltip.compactmachines.solid_wall.hint": "警告！非创造模式玩家无法破坏！",
+  "tooltip.compactmachines.machine.hint": "一个 %1$s 拥有 %2$s 的空间。",
+  "tooltip.compactmachines.tunnel_type": "类型 ID：%1$s",
+
+  "messages.compactmachines.psd.spawnpoint_set": "入口已设置在所站的地方！",
+  "messages.compactmachines.no_machine_data": "未加载机械数据，请汇报该问题。",
+
+  "block.compactmachines.machine": "压缩空间机械",
+  "block.compactmachines.machine_tiny": "压缩空间机械（微型）",
+  "block.compactmachines.machine_small": "压缩空间机械（小型）",
+  "block.compactmachines.machine_normal": "压缩空间机械（普通）",
+  "block.compactmachines.machine_large": "压缩空间机械（大型）",
+  "block.compactmachines.machine_giant": "压缩空间机械（巨型）",
+  "block.compactmachines.machine_maximum": "压缩空间机械（超大型）",
+
+  "block.compactmachines.solid_wall": "紧实型压缩空间壁",
+  "block.compactmachines.wall": "压缩空间壁",
+  "block.compactmachines.tunnel_wall": "接口",
+
+  "item.compactmachines.machine_tiny": "压缩空间机械（微型）",
+  "item.compactmachines.machine_small": "压缩空间机械（小型）",
+  "item.compactmachines.machine_normal": "压缩空间机械（普通）",
+  "item.compactmachines.machine_large": "压缩空间机械（大型）",
+  "item.compactmachines.machine_giant": "压缩空间机械（巨型）",
+  "item.compactmachines.machine_maximum": "压缩空间机械（超大型）",
+
+  "item.compactmachines.personal_shrinking_device": "传送器",
+
+  "item.compactmachines.tunnels.item": "物品接口",
+  "item.compactmachines.tunnels.redstone_in": "红石接口（输入）",
+  "item.compactmachines.tunnels.redstone_out": "红石接口（输出）",
+
+  "compactmachines.cannot_enter": "你摸索着传送器的用法，但没用，它就是不工作。",
+
+  "compactmachines.connected_block": "已连接：%s",
+  "compactmachines.direction.side": "方向：%s",
+  "compactmachines.direction.up": "顶面",
+  "compactmachines.direction.down": "底面",
+  "compactmachines.direction.north": "北面",
+  "compactmachines.direction.south": "南面",
+  "compactmachines.direction.west": "西面",
+  "compactmachines.direction.east": "东面",
+
+  "compactmachines.psd.pages.machines.title": "压缩空间机械",
+  "compactmachines.psd.pages.machines": "压缩空间机械是该模组的核心物品。它能让你在一个方块的空间内建立大型空间并与外部世界相连接。它们的尺寸从 3x3x3 到 13x13x13 不等。\n\n你可以用接口把内部和外部连接起来，来运输物品、液体等。\n\n你可以用传送器右击进入一个压缩空间机械。请使用 JEI 来查看合成表。",
+
+  "compactmachines.errors.unknown_tunnel_type": "未知接口类型（%s）"
+}


### PR DESCRIPTION
翻译基本取自1.12.2，补充部分新增key

- [x] 我已阅读注意事项 [#847](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/847)
- [x] 我已标记PR以便审查（见`CONTRIBUTING.md`）
- [x] 我已确认文件路径、分支均正确：
    - 如果是 1.12 翻译，应该是: `projects/1.12.2/assets/curseforge 域名/模组资源 id/lang/zh_cn.lang`
    - 如果是 1.15-1.16 翻译，应该是: `projects/1.16.1/assets/curseforge 域名/模组资源 id/lang/zh_cn.json`
- [x] 我已确认语言文件名大小写正确，所有的语言文件全为小写；
- [x] 我已阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
