### PR TITLE
[M] 修复模块化魔法中的错别字

### DIFF
--- a/projects/1.12.2/assets/modular-magic/modularmagic/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/modular-magic/modularmagic/lang/zh_cn.lang
@@ -25,7 +25,7 @@ info.modularmagic.lp=LP
 info.modularmagic.lifeessence=生命源质
 info.modularmagic.grid.required=需要 %f GP
 info.modularmagic.grid.produced=产生 %f GP
-info.modularmagic.rainbow.required=需要一个工作的彩虹发动机
+info.modularmagic.rainbow.required=需要一个工作的彩虹发电机
 
 tile.blockwillproviderinput.name=恶魔意志输入仓
 tile.blockwillprovideroutput.name=恶魔意志输出仓


### PR DESCRIPTION
- [x] 我已阅读注意事项 [#847](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/847)
- [x] 我已对 PR 作出标记以便审查（见 [CONTRIBUTING.md](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)）
- [x] 我已确认文件路径、分支均正确：
    - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/CurseForge 项目名称/ModID/lang/zh_cn.lang`
    - 如果是 1.15-1.16 翻译，应该是：`projects/1.16.1/assets/CurseForge 项目名称/ModID/lang/zh_cn.json`
- [x] 我已确认语言文件名大小写正确，所有的语言文件名称全为小写；
- [x] 我已上传英文文件以供审查；
- [x] 我已阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议（CC BY-NC-SA 4.0 协议）](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)

真不知道我校对的时候在想什么x
