### PR TITLE
[R] 纠正古代战争一处误译

### DIFF
--- a/projects/1.12.2/assets/ancient-warfare-2/ancientwarfare/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/ancient-warfare-2/ancientwarfare/lang/zh_cn.lang
@@ -154,7 +154,7 @@ item.coin.gold.name=金龙币
 item.coin.silver.name=银鹿币
 item.coin.copper.name=铜鸮币
 item.coin.ancient.name=古币
-item.coin.ancient.tooltip=%1$s"米诺西亚的旧物，如今只有其硬币遗存 - 彼之过往繁华就这般逝去。"
+item.coin.ancient.tooltip=%1$s"米诺西亚之物，如今只有其硬币遗存——世间繁华就这般终归尘土。"
 
 #vehicle
 

--- a/projects/1.12.2/assets/ancient-warfare-2/ancientwarfare/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/ancient-warfare-2/ancientwarfare/lang/zh_cn.lang
@@ -154,7 +154,7 @@ item.coin.gold.name=金龙币
 item.coin.silver.name=银鹿币
 item.coin.copper.name=铜鸮币
 item.coin.ancient.name=古币
-item.coin.ancient.tooltip=%1$s"米诺西亚的旧物，如今只有其硬币遗存 - 彼之过往荣耀就这般逝去。"
+item.coin.ancient.tooltip=%1$s"米诺西亚的旧物，如今只有其硬币遗存 - 彼之过往繁华就这般逝去。"
 
 #vehicle
 

--- a/projects/1.12.2/assets/ancient-warfare-2/ancientwarfare/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/ancient-warfare-2/ancientwarfare/lang/zh_cn.lang
@@ -154,7 +154,7 @@ item.coin.gold.name=金龙币
 item.coin.silver.name=银鹿币
 item.coin.copper.name=铜鸮币
 item.coin.ancient.name=古币
-item.coin.ancient.tooltip=%1$s"米诺斯，只余其货币 - 流通于世"
+item.coin.ancient.tooltip=%1$s"米诺西亚的旧物，如今只有其硬币遗存 - 彼之过往荣耀就这般逝去。"
 
 #vehicle
 

--- a/projects/1.12.2/assets/ancient-warfare-2/ancientwarfare/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/ancient-warfare-2/ancientwarfare/lang/zh_cn.lang
@@ -154,7 +154,7 @@ item.coin.gold.name=金龙币
 item.coin.silver.name=银鹿币
 item.coin.copper.name=铜鸮币
 item.coin.ancient.name=古币
-item.coin.ancient.tooltip=%1$s"米诺西亚之物，如今只有其硬币遗存——世间繁华就这般终归尘土。"
+item.coin.ancient.tooltip=%1$s"米诺西亚之物，如今只有其硬币遗存——世间荣光就这般终归尘土。"
 
 #vehicle
 


### PR DESCRIPTION
Sic transit gloria mundi. ——世间荣耀就此逝去。
这句拉丁文格言意指事物的不稳定性，类似于“宫阙万间都做了土”，而非“流通于世”。
类似的使用案例：《献给莱博维茨的赞歌》中，传教士在核战开始后，默默望着核爆的闪光并祈祷了片刻，随后说出“Sic transit gloria mundi”这句话，便登上宇宙飞船离开了地球。

- [x] 我已阅读注意事项 [#847](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/847)
- [x] 我已对 PR 作出标记以便审查（见 [CONTRIBUTING.md](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)）
- [x] 我已确认文件路径、分支均正确：
    - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/CurseForge 项目名称/ModID/lang/zh_cn.lang`
    - 如果是 1.15-1.16 翻译，应该是：`projects/1.16.1/assets/CurseForge 项目名称/ModID/lang/zh_cn.json`
- [x] 我已确认语言文件名大小写正确，所有的语言文件名称全为小写；
- [x] 我已上传英文文件以供审查；
- [x] 我已阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议（CC BY-NC-SA 4.0 协议）](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)