### PR TITLE
[R]添加心之容器丨1.16

### DIFF
--- a/projects/1.16.1/assets/baubley-heart-canisters/bhc/lang/en_us.json
+++ b/projects/1.16.1/assets/baubley-heart-canisters/bhc/lang/en_us.json
@@ -1,0 +1,17 @@
+{
+  "itemGroup.bhcTab" : "Baubley Heart Canisters",
+  "item.bhc.red_heart" : "Miniature Red Heart",
+  "item.bhc.yellow_heart" : "Miniature Yellow Heart",
+  "item.bhc.green_heart" : "Miniature Green Heart",
+  "item.bhc.blue_heart" : "Miniature Blue Heart",
+  "item.bhc.canister" : "Canister",
+  "item.bhc.red_heart_canister" : "Red Heart Canister",
+  "item.bhc.yellow_heart_canister" : "Yellow Heart Canister",
+  "item.bhc.green_heart_canister" : "Green Heart Canister",
+  "item.bhc.blue_heart_canister" : "Blue Heart Canister",
+  "item.bhc.wither_bone" : "Wither Bone",
+  "item.bhc.relic_apple" : "Relic Apple",
+  "item.bhc.heart_amulet" : "Heart Amulet",
+  "container.bhc.heart_amulet" : "Heart Amulet",
+  "tooltip.bhc.heartamulet": "Right click to open!"
+}

--- a/projects/1.16.1/assets/baubley-heart-canisters/bhc/lang/zh_cn.json
+++ b/projects/1.16.1/assets/baubley-heart-canisters/bhc/lang/zh_cn.json
@@ -1,0 +1,17 @@
+{
+  "itemGroup.bhcTab" : "心之容器",
+  "item.bhc.red_heart" : "微型红心",
+  "item.bhc.yellow_heart" : "微型黄心",
+  "item.bhc.green_heart" : "微型绿心",
+  "item.bhc.blue_heart" : "微型蓝心",
+  "item.bhc.canister" : "心之容器",
+  "item.bhc.red_heart_canister" : "红心容器",
+  "item.bhc.yellow_heart_canister" : "黄心容器",
+  "item.bhc.green_heart_canister" : "绿心容器",
+  "item.bhc.blue_heart_canister" : "蓝心容器",
+  "item.bhc.wither_bone" : "凋灵之骨",
+  "item.bhc.relic_apple" : "遗物苹果",
+  "item.bhc.heart_amulet" : "心形吊坠",
+  "container.bhc.heart_amulet" : "心形吊坠",
+  "tooltip.bhc.heartamulet": "单击右键打开！"
+}


### PR DESCRIPTION
整个库都删了重新传(

- [x] 我已阅读注意事项 [#847](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/847)
- [x] 我已对 PR 作出标记以便审查（见 [CONTRIBUTING.md](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)）
- [x] 我已确认文件路径、分支均正确：
    - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/CurseForge 项目名称/ModID/lang/zh_cn.lang`
    - 如果是 1.15-1.16 翻译，应该是：`projects/1.16.1/assets/CurseForge 项目名称/ModID/lang/zh_cn.json`
- [x] 我已确认语言文件名大小写正确，所有的语言文件名称全为小写；
- [x] 我已上传英文文件以供审查；
- [x] 我已阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议（CC BY-NC-SA 4.0 协议）](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
