### PR TITLE
[M] Fix geolosys error text in zh_cn.lang

### DIFF
--- a/projects/1.12.2/assets/geolosys/geolosys/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/geolosys/geolosys/lang/zh_cn.lang
@@ -38,7 +38,7 @@ geolosys.guide.chapter.cinnabar.text=朱砂可在§3海拔 Y = <maxY> 到 Y = <m
 geolosys.guide.chapter.coal.name=煤炭
 geolosys.guide.chapter.coal.text=煤炭可在§3海拔 Y = <maxY> 到 Y = <minY> §0之间找到；若有其他 Mod 添加了硫磺，煤炭矿脉也会产出硫磺。除普通煤炭外，煤矿石也会掉落泥炭、褐煤、烟煤或无烟煤，具体掉落哪一种与你所在的§l深度§r§0有关。上文中掉落物是按出现高度从高到低，以及在熔炉中燃烧时间从短到长的顺序排列的。
 geolosys.guide.chapter.cofh_mods.name=Thermal Foundation
-geolosys.guide.chapter.cofh_mods.text=若安装了 Thermal Foundation，朱砂矿会有 3.33% 概率靠落朱砂。
+geolosys.guide.chapter.cofh_mods.text=若安装了 Thermal Foundation，朱砂矿会有 3.33% 概率掉落朱砂。
 geolosys.guide.chapter.extra_utils.name=Extra Utilities 2
 geolosys.guide.chapter.extra_utils.text=若安装了 Extra Utilities 2，朱砂矿会有 3.33% 概率掉落共振红石水晶。
 geolosys.guide.chapter.extreme_reactors.name=Extreme Reactors


### PR DESCRIPTION
- [x] 我已阅读注意事项 [#847](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/847)；
- [x] 我已确定中文文件中没有未翻译的文本，如有已删除；
- [x] 我已对 PR 作出标记以便审查（见 [CONTRIBUTING.md](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)）；
- [x] 我已确认文件路径、分支均正确：
    - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/CurseForge 项目名称/ModID/lang/zh_cn.lang`
    - 如果是 1.15-1.16 翻译，应该是：`projects/1.16/assets/CurseForge 项目名称/ModID/lang/zh_cn.json`
- [x] 我已确认语言文件名大小写正确，所有的语言文件名称全为小写；
- [x] 我已上传英文文件以供审查；
- [x] 我已阅读相关协议，同意对于本项目的贡献的许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议（CC BY-NC-SA 4.0 协议）](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/1.10.2/LICENSE)
