### PR TITLE
[R] fix(1.16/signpost): 回退变更 & 修改语句

### DIFF
--- a/projects/1.16/assets/signpost/signpost/lang/zh_cn.json
+++ b/projects/1.16/assets/signpost/signpost/lang/zh_cn.json
@@ -39,7 +39,7 @@
   
     "signpost.discovered": "你现在可以使用路标前往%s了。",
     "signpost.not_discovered": "你还没有发现%s",
-    "signpost.too_far_away": "你无法抵达这么远的地方（距离：%s，上限：%s）",
+    "signpost.too_far_away": "你无法抵达这么远的地方（距离：%s，最远：%s）",
     "signpost.waystone_not_found": "指路石%s不存在。",
     "signpost.no_waystones": "你还没有发现任何指路石。",
     "signpost.too_expensive": "你没有所需物品（%d %s）。",
@@ -60,5 +60,5 @@
   
     "itemGroup.signpost": "路标",
   
-    "signpost.no_teleport_waystones_mod": "你不能使用路标前往这个指路石，需要使用传送卷轴等类似物品。"
+    "signpost.no_teleport_waystones_mod": "你不能使用路标前往这个指路石，需要使用传送卷轴或类似物品。"
   }


### PR DESCRIPTION
- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang`
  - 如果是 1.16 翻译，应该是：`projects/1.16/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
- [x] 我已确认有参照的英文原文，若无请上传或更新英文原文；
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [ ] 刷新 PR 的标签/状态，有需要再点击；
