### PR TITLE
[R] betternether 翻译增加 单条

### DIFF
--- a/projects/1.12.2/assets/betternether/betternether/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/betternether/betternether/lang/zh_cn.lang
@@ -130,6 +130,7 @@ item.cincinnasite_axe.name=辛西纳石斧
 item.cincinnasite_axe_diamond.name=辛西纳钻石斧
 tile.bone_reed_door.name=芦苇骨门
 tile.bone_cincinnasite_door.name=辛西纳石骨门
+tile.chest_of_drawers.name=画者之箱
 container.chest_of_drawers=画者之箱
 commands.findnethercity.usage=用法错误，必须是 /findnethercity 或 /findnethercity x y z
 commands.findnethercity.usage.coordinates=错误的坐标


### PR DESCRIPTION
bone_block 似乎硬编码 Smooth Bone Block 无法修改为 骨块
fix bug

- [ ] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [ ] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [ ] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang`
  - 如果是 1.16 翻译，应该是：`projects/1.16/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
- [ ] 我已确认有参照的英文原文，若无请上传或更新英文原文；
- [ ] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [ ] 刷新 PR 的标签/状态，有需要再点击；
