### PR TITLE
[R] Cyclic 循环，反重力环->反重力戒指

### DIFF
--- a/projects/1.16/assets/cyclic/cyclic/lang/zh_cn.json
+++ b/projects/1.16/assets/cyclic/cyclic/lang/zh_cn.json
@@ -506,7 +506,7 @@
   "item.cyclic.carbon_paper": "复写纸",
   "item.cyclic.carbon_paper.copied": "复制的告示牌数据",
   "item.cyclic.carbon_paper.guide": "复写纸可以用来把一个告示牌的内容复制到另一个告示牌上。复制的文本可以在上炼药锅中清除。",
-  "item.cyclic.antigravity": "反重力环",
+  "item.cyclic.antigravity": "反重力戒指",
   "item.cyclic.antigravity.tooltip": "空中行走，忽略重力",
   "item.cyclic.antigravity.guide": "当激活时，你可以站在空中并停留，跳跃时不会往下掉。",
   "item.cyclic.charm_antidote": "抗毒护符",

--- a/projects/1.18/assets/cyclic/cyclic/lang/zh_cn.json
+++ b/projects/1.18/assets/cyclic/cyclic/lang/zh_cn.json
@@ -506,7 +506,7 @@
   "item.cyclic.carbon_paper": "复写纸",
   "item.cyclic.carbon_paper.copied": "复制的告示牌数据",
   "item.cyclic.carbon_paper.guide": "复写纸可以用来把一个告示牌的内容复制到另一个告示牌上。复制的文本可以在上炼药锅中清除。",
-  "item.cyclic.antigravity": "反重力环",
+  "item.cyclic.antigravity": "反重力戒指",
   "item.cyclic.antigravity.tooltip": "空中行走，忽略重力",
   "item.cyclic.antigravity.guide": "当激活时，你可以站在空中并停留，跳跃时不会往下掉。",
   "item.cyclic.charm_antidote": "抗毒护符",


### PR DESCRIPTION
- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang`
  - 如果是 1.16 翻译，应该是：`projects/1.16/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
  - 如果是 1.18 翻译，应该是：`projects/1.18/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [ ] 刷新 PR 的标签/状态，有需要再点击；

# 请至少等待 3 天再合并

## 理由是循环的使用玩家多，而且据称该物品的出场率较高。

### 理由

Curios API 的 ring 译为“戒指”，与之统一。

### 相关图片

![image](https://user-images.githubusercontent.com/37480168/158014723-d852997d-77f8-41ef-92e5-63697bc79975.png)

![XFERZK) A@`M_M%138K$Z G](https://user-images.githubusercontent.com/37480168/158014727-ce1f6bf8-144a-4a8b-82d8-9f4d24590beb.png)

