### PR TITLE
[R]Upgraded Netherite : Creativerite的翻译提交

### DIFF
--- a/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/en_us.json
+++ b/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/en_us.json
@@ -1,0 +1,52 @@
+{
+  "itemGroup.upgradednetheritecreativeTab": "Upgraded Netherite Creative",
+
+  "item.upgradednetherite_creative.creative_upgraded_netherite_ingot": "Creativerite Ingot",
+
+  "item.upgradednetherite_creative.creative_upgraded_netherite_helmet": "Creativerite Helmet",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_chestplate": "Creativerite Chestplate",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_leggings": "Creativerite Leggings",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_boots": "Creativerite Boots",
+
+  "item.upgradednetherite_creative.creative_upgraded_netherite_horse_armor": "Creativerite Horse Armor",
+
+  "item.upgradednetherite_creative.creative_upgraded_netherite_sword": "Creativerite Sword",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_pickaxe": "Creativerite Pickaxe",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shovel": "Creativerite Shovel",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_axe": "Creativerite Axe",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_bow": "Creativerite Bow",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_crossbow": "Creativerite Crossbow",
+
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield": "Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.black": "Black Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.red": "Red Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.green": "Green Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.brown": "Brown Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.blue": "Blue Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.purple": "Purple Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.cyan": "Cyan Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.light_gray": "Light Gray Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.gray": "Gray Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.pink": "Pink Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.lime": "Lime Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.yellow": "Yellow Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.light_blue": "Light Blue Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.magenta": "Magenta Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.orange": "Orange Creativerite Shield",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.white": "White Creativerite Shield",
+
+  "upgradednetherite_creative.Creative_Bonus.TT": "§7• §6Flying§7.",
+  "upgradednetherite_creative.Creative_Bonus2.TT": "§7• §6No Damage§7.",
+  "upgradednetherite_creative.Creative_Bonus3.TT": "§7• §6No Harmful Effect§7.",
+  "upgradednetherite_creative.Creative_Bonus4.TT": "§7• §6Saturation§7.",
+  "upgradednetherite_creative.Creative_Bonus5.TT": "§7• §6Heal§7.",
+
+  "upgradednetherite_creative.Creative_Bonus_Weapon.TT": "§7• §6Insta Kill§7.",
+  "upgradednetherite_creative.Creative_Bonus_Tool.TT": "§7• §6Insta Break§7.",
+
+  "upgradednetherite.Blank.TT": "",
+  "upgradednetherite.HoldShift.TT": "Hold §b§nShift§r§f for infos.",
+  "upgradednetherite.Bonus.TT": "§a§lBonus",
+  "upgradednetherite.SetBonus.TT": "§a§lSet Bonus (%1$s§a§l)",
+  "upgradednetherite.WhenBlocking.TT": "§e§lWhen Blocking"
+}

--- a/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
+++ b/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
@@ -36,8 +36,8 @@
   "item.upgradednetherite_creative.creative_upgraded_netherite_shield.white": "白色创造下界合金盾牌",
 
   "upgradednetherite_creative.Creative_Bonus.TT": "§7• §6飞行§7.",
-  "upgradednetherite_creative.Creative_Bonus2.TT": "§7• §6无法损坏§7.",
-  "upgradednetherite_creative.Creative_Bonus3.TT": "§7• §6免疫异常状态§7.",
+  "upgradednetherite_creative.Creative_Bonus2.TT": "§7• §6不毁§7.",
+  "upgradednetherite_creative.Creative_Bonus3.TT": "§7• §6免疫有害效果§7.",
   "upgradednetherite_creative.Creative_Bonus4.TT": "§7• §6饱和§7.",
   "upgradednetherite_creative.Creative_Bonus5.TT": "§7• §6再生§7.",
 

--- a/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
+++ b/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
@@ -47,6 +47,6 @@
   "upgradednetherite.Blank.TT": "",
   "upgradednetherite.HoldShift.TT": "按住 §b§nShift§r§f 键查看详情。",
   "upgradednetherite.Bonus.TT": "§a§l增益",
-  "upgradednetherite.SetBonus.TT": "§a§l套装增益(%1$s§a§l)",
+  "upgradednetherite.SetBonus.TT": "§a§l套装增益（%1$s§a§l）",
   "upgradednetherite.WhenBlocking.TT": "§e§l格挡时"
 }

--- a/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
+++ b/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
@@ -47,6 +47,6 @@
   "upgradednetherite.Blank.TT": "",
   "upgradednetherite.HoldShift.TT": "按住 §b§nShift§r§f 键查看详情。",
   "upgradednetherite.Bonus.TT": "§a§l增益",
-  "upgradednetherite.SetBonus.TT": "§a§l套装增益",
+  "upgradednetherite.SetBonus.TT": "§a§l套装增益(%1$s§a§l)",
   "upgradednetherite.WhenBlocking.TT": "§e§l格挡时"
 }

--- a/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
+++ b/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
@@ -43,4 +43,10 @@
 
   "upgradednetherite_creative.Creative_Bonus_Weapon.TT": "§7• §6瞬间秒杀§7.",
   "upgradednetherite_creative.Creative_Bonus_Tool.TT": "§7• §6瞬间破坏§7."
+  
+  "upgradednetherite.Blank.TT": "",
+  "upgradednetherite.HoldShift.TT": "按住 §b§nShift§r§f 键查看详情。",
+  "upgradednetherite.Bonus.TT": "§a§l增益",
+  "upgradednetherite.SetBonus.TT": "§a§l套装增益",
+  "upgradednetherite.WhenBlocking.TT": "§e§l格挡时",
 }

--- a/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
+++ b/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
@@ -1,0 +1,46 @@
+{
+  "itemGroup.upgradednetheritecreativeTab": "下界合金增强：创造",
+
+  "item.upgradednetherite_creative.creative_upgraded_netherite_ingot": "创造下界合金锭",
+
+  "item.upgradednetherite_creative.creative_upgraded_netherite_helmet": "创造下界合金头盔",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_chestplate": "创造下界合金胸甲",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_leggings": "创造下界合金护腿",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_boots": "创造下界合金靴子",
+
+  "item.upgradednetherite_creative.creative_upgraded_netherite_horse_armor": "创造下界合金马铠",
+
+  "item.upgradednetherite_creative.creative_upgraded_netherite_sword": "创造下界合金剑",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_pickaxe": "创造下界合金镐",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shovel": "创造下界合金锹",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_axe": "创造下界合金斧",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_bow": "创造下界合金弓",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_crossbow": "创造下界合金弩",
+
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield": "创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.black": "黑色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.red": "红色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.green": "绿色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.brown": "棕色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.blue": "蓝色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.purple": "紫色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.cyan": "青色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.light_gray": "淡灰色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.gray": "灰色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.pink": "粉色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.lime": "黄绿色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.yellow": "黄色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.light_blue": "淡蓝色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.magenta": "品红色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.orange": "橙色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.white": "白色创造下界合金盾牌",
+
+  "upgradednetherite_creative.Creative_Bonus.TT": "§7• §6飞行§7.",
+  "upgradednetherite_creative.Creative_Bonus2.TT": "§7• §6无法损坏§7.",
+  "upgradednetherite_creative.Creative_Bonus3.TT": "§7• §6免疫异常状态§7.",
+  "upgradednetherite_creative.Creative_Bonus4.TT": "§7• §6饱和§7.",
+  "upgradednetherite_creative.Creative_Bonus5.TT": "§7• §6再生§7.",
+
+  "upgradednetherite_creative.Creative_Bonus_Weapon.TT": "§7• §6瞬间秒杀§7.",
+  "upgradednetherite_creative.Creative_Bonus_Tool.TT": "§7• §6瞬间破坏§7."
+}

--- a/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
+++ b/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
@@ -41,7 +41,7 @@
   "upgradednetherite_creative.Creative_Bonus4.TT": "§7• §6饱和§7.",
   "upgradednetherite_creative.Creative_Bonus5.TT": "§7• §6再生§7.",
 
-  "upgradednetherite_creative.Creative_Bonus_Weapon.TT": "§7• §6瞬间秒杀§7.",
+  "upgradednetherite_creative.Creative_Bonus_Weapon.TT": "§7• §6瞬间击杀§7.",
   "upgradednetherite_creative.Creative_Bonus_Tool.TT": "§7• §6瞬间破坏§7.",
   
   "upgradednetherite.Blank.TT": "",

--- a/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
+++ b/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
@@ -42,7 +42,7 @@
   "upgradednetherite_creative.Creative_Bonus5.TT": "§7• §6再生§7.",
 
   "upgradednetherite_creative.Creative_Bonus_Weapon.TT": "§7• §6瞬间秒杀§7.",
-  "upgradednetherite_creative.Creative_Bonus_Tool.TT": "§7• §6瞬间破坏§7."
+  "upgradednetherite_creative.Creative_Bonus_Tool.TT": "§7• §6瞬间破坏§7.",
   
   "upgradednetherite.Blank.TT": "",
   "upgradednetherite.HoldShift.TT": "按住 §b§nShift§r§f 键查看详情。",

--- a/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
+++ b/projects/1.18/assets/upgraded-netherite-creativerite/upgradednetherite_creative/lang/zh_cn.json
@@ -27,7 +27,7 @@
   "item.upgradednetherite_creative.creative_upgraded_netherite_shield.cyan": "青色创造下界合金盾牌",
   "item.upgradednetherite_creative.creative_upgraded_netherite_shield.light_gray": "淡灰色创造下界合金盾牌",
   "item.upgradednetherite_creative.creative_upgraded_netherite_shield.gray": "灰色创造下界合金盾牌",
-  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.pink": "粉色创造下界合金盾牌",
+  "item.upgradednetherite_creative.creative_upgraded_netherite_shield.pink": "粉红色创造下界合金盾牌",
   "item.upgradednetherite_creative.creative_upgraded_netherite_shield.lime": "黄绿色创造下界合金盾牌",
   "item.upgradednetherite_creative.creative_upgraded_netherite_shield.yellow": "黄色创造下界合金盾牌",
   "item.upgradednetherite_creative.creative_upgraded_netherite_shield.light_blue": "淡蓝色创造下界合金盾牌",
@@ -48,5 +48,5 @@
   "upgradednetherite.HoldShift.TT": "按住 §b§nShift§r§f 键查看详情。",
   "upgradednetherite.Bonus.TT": "§a§l增益",
   "upgradednetherite.SetBonus.TT": "§a§l套装增益",
-  "upgradednetherite.WhenBlocking.TT": "§e§l格挡时",
+  "upgradednetherite.WhenBlocking.TT": "§e§l格挡时"
 }


### PR DESCRIPTION
- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang`
  - 如果是 1.16 翻译，应该是：`projects/1.16/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
  - 如果是 1.18 翻译，应该是：`projects/1.18/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [ ] 刷新 PR 的标签/状态，有需要再点击；
