### PR TITLE
[R] Dark Utilities 错误翻译修正

### DIFF
--- a/projects/1.16/assets/dark-utilities/darkutils/lang/zh_cn.json
+++ b/projects/1.16/assets/dark-utilities/darkutils/lang/zh_cn.json
@@ -28,7 +28,7 @@
   "tooltip.darkutils.rune_hunger.short": "让生物饥饿。",
   "tooltip.darkutils.rune_fire.short": "让生物着火。",
   "tooltip.darkutils.rune_poison.short": "碰到的生物会中毒。",
-  "item.darkutils.book_galactic": "网络之书",
+  "item.darkutils.book_galactic": "银河之书",
   "tooltip.darkutils.charm_gluttony.long": "允许使用者立即吃完食物。放置在物品栏任何一处或副手或饰品栏都有效。",
   "tooltip.darkutils.charm_sleep.long": "允许玩家立即睡完觉。放置在物品栏任何一处或副手或饰品栏都有效。",
   "tooltip.darkutils.charm_portal.long": "允许穿戴者立即穿过传送门。放置在物品栏任何一处或副手或饰品栏都有效。",
@@ -155,11 +155,11 @@
   "block.darkutils.blank_plate": "空白板",
   "itemGroup.darkutils": "Dark Utilities",
   "tooltip.darkutils.book_restore.long": "当与锻造台中的任何工具组合时，该工具的维修成本惩罚将重置。",
-  "tooltip.darkutils.book_runelic.long": "当在锻造台中与任何工具组合时，该工具将被重命名为Runelic。",
-  "tooltip.darkutils.book_galactic.long": "当在锻造台中与任何工具组合时，该工具将被重命名为Standard Galactic Alphabe。",
+  "tooltip.darkutils.book_runelic.long": "当在锻造台中与任何工具组合时，该工具将以Runelic字体被重命名。",
+  "tooltip.darkutils.book_galactic.long": "当在锻造台中与任何工具组合时，该工具将以标准银河字母字体被重命名。",
   "tooltip.darkutils.book_restore.short": "当与锻造台上的工具组合时，重置修复成本惩罚。",
-  "tooltip.darkutils.book_runelic.short": "重命名工具以使用Runelic（当在锻造台上使用时）。",
-  "tooltip.darkutils.book_galactic.short": "重命名工具以使用Standard Galactic Alphabet （当在锻造台上使用时）。",
-  "item.darkutils.book_restore": "恢复之书",
-  "item.darkutils.book_runelic": "遗迹之书"
+  "tooltip.darkutils.book_runelic.short": "在锻造台上使用，来以Runelic字体重命名工具。",
+  "tooltip.darkutils.book_galactic.short": "在锻造台上使用，来以标准银河字母字体重命名工具。",
+  "item.darkutils.book_restore": "修复之书",
+  "item.darkutils.book_runelic": "Runelic之书"
 }

--- a/projects/1.18/assets/dark-utilities/darkutils/lang/zh_cn.json
+++ b/projects/1.18/assets/dark-utilities/darkutils/lang/zh_cn.json
@@ -28,7 +28,7 @@
   "tooltip.darkutils.rune_hunger.short": "让生物饥饿。",
   "tooltip.darkutils.rune_fire.short": "让生物着火。",
   "tooltip.darkutils.rune_poison.short": "碰到的生物会中毒。",
-  "item.darkutils.book_galactic": "网络之书",
+  "item.darkutils.book_galactic": "银河之书",
   "tooltip.darkutils.charm_gluttony.long": "允许使用者立即吃完食物。放置在物品栏任何一处或副手或饰品栏都有效。",
   "tooltip.darkutils.charm_sleep.long": "允许玩家立即睡完觉。放置在物品栏任何一处或副手或饰品栏都有效。",
   "tooltip.darkutils.charm_portal.long": "允许穿戴者立即穿过传送门。放置在物品栏任何一处或副手或饰品栏都有效。",
@@ -155,11 +155,11 @@
   "block.darkutils.blank_plate": "空白板",
   "itemGroup.darkutils": "Dark Utilities",
   "tooltip.darkutils.book_restore.long": "当与锻造台中的任何工具组合时，该工具的维修成本惩罚将重置。",
-  "tooltip.darkutils.book_runelic.long": "当在锻造台中与任何工具组合时，该工具将被重命名为Runelic。",
-  "tooltip.darkutils.book_galactic.long": "当在锻造台中与任何工具组合时，该工具将被重命名为Standard Galactic Alphabe。",
+  "tooltip.darkutils.book_runelic.long": "当在锻造台中与任何工具组合时，该工具将以Runelic字体被重命名。",
+  "tooltip.darkutils.book_galactic.long": "当在锻造台中与任何工具组合时，该工具将以标准银河字母字体被重命名。",
   "tooltip.darkutils.book_restore.short": "当与锻造台上的工具组合时，重置修复成本惩罚。",
-  "tooltip.darkutils.book_runelic.short": "重命名工具以使用Runelic（当在锻造台上使用时）。",
-  "tooltip.darkutils.book_galactic.short": "重命名工具以使用Standard Galactic Alphabet （当在锻造台上使用时）。",
-  "item.darkutils.book_restore": "恢复之书",
-  "item.darkutils.book_runelic": "遗迹之书"
+  "tooltip.darkutils.book_runelic.short": "在锻造台上使用，来以Runelic字体重命名工具。",
+  "tooltip.darkutils.book_galactic.short": "在锻造台上使用，来以标准银河字母字体重命名工具。",
+  "item.darkutils.book_restore": "修复之书",
+  "item.darkutils.book_runelic": "Runelic之书"
 }


### PR DESCRIPTION
<!--要勾选下面的复选框 可以将文本[ ]改为[x]-->

- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang`
  - 如果是 1.16 翻译，应该是：`projects/1.16/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
  - 如果是 1.18 翻译，应该是：`projects/1.18/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [x] 刷新 PR 的标签/状态，有需要再点击；
