### PR TITLE
[R] Backslot 翻译提交

### DIFF
--- a/projects/1.16/assets/backslot/backslot/lang/en_us.json
+++ b/projects/1.16/assets/backslot/backslot/lang/en_us.json
@@ -15,10 +15,4 @@
   "text.autoconfig.backslot.option.beltSlot_x": "Beltslot X",
   "text.autoconfig.backslot.option.beltSlot_y": "Beltslot Y",
   "text.autoconfig.backslot.option.backSlot_x.@PrefixText": "Inventory Slot Positions",
-  "text.autoconfig.backslot.option.switch_beltslot_side": "Switch Beltslot side",
-  "text.autoconfig.backslot.option.offhand_switch": "Offhand switch",
-  "text.autoconfig.backslot.option.offhand_shield": "Offhand shield switch",
-  "text.autoconfig.backslot.option.offhand_fallback": "Offhand fallback",
-  "text.autoconfig.backslot.option.put_aside": "Put aside if full hand",
-  "text.autoconfig.backslot.option.drop_holding": "Drop item when no space"
 }

--- a/projects/1.16/assets/backslot/backslot/lang/en_us.json
+++ b/projects/1.16/assets/backslot/backslot/lang/en_us.json
@@ -14,5 +14,5 @@
   "text.autoconfig.backslot.option.backSlot_y": "Backslot Y",
   "text.autoconfig.backslot.option.beltSlot_x": "Beltslot X",
   "text.autoconfig.backslot.option.beltSlot_y": "Beltslot Y",
-  "text.autoconfig.backslot.option.backSlot_x.@PrefixText": "Inventory Slot Positions",
+  "text.autoconfig.backslot.option.backSlot_x.@PrefixText": "Inventory Slot Positions"
 }

--- a/projects/1.16/assets/backslot/backslot/lang/en_us.json
+++ b/projects/1.16/assets/backslot/backslot/lang/en_us.json
@@ -1,4 +1,24 @@
 {
   "key.backslot.switch_backslot": "Back Slot Switch",
-  "category.backslot.key": "Back Slot"
+  "key.backslot.switch_beltslot": "Belt Slot Switch",
+  "category.backslot.key": "Back Slot",
+  "text.autoconfig.backslot.title": "BackSlot Config",
+  "text.autoconfig.backslot.category.default": "Default Settings",
+  "text.autoconfig.backslot.category.advanced_settings": "Advanced Settings",
+  "text.autoconfig.backslot.option.backslot_scale": "BackSlot item scale",
+  "text.autoconfig.backslot.option.beltslot_scale": "BeltSlot item scale",
+  "text.autoconfig.backslot.option.backslot_sounds": "BackSlot sounds",
+  "text.autoconfig.backslot.option.change_slot_arrangement": "Change slot arrangement",
+  "text.autoconfig.backslot.option.disable_backslot_hud": "Disable Backslot HUD",
+  "text.autoconfig.backslot.option.backSlot_x": "Backslot X",
+  "text.autoconfig.backslot.option.backSlot_y": "Backslot Y",
+  "text.autoconfig.backslot.option.beltSlot_x": "Beltslot X",
+  "text.autoconfig.backslot.option.beltSlot_y": "Beltslot Y",
+  "text.autoconfig.backslot.option.backSlot_x.@PrefixText": "Inventory Slot Positions",
+  "text.autoconfig.backslot.option.switch_beltslot_side": "Switch Beltslot side",
+  "text.autoconfig.backslot.option.offhand_switch": "Offhand switch",
+  "text.autoconfig.backslot.option.offhand_shield": "Offhand shield switch",
+  "text.autoconfig.backslot.option.offhand_fallback": "Offhand fallback",
+  "text.autoconfig.backslot.option.put_aside": "Put aside if full hand",
+  "text.autoconfig.backslot.option.drop_holding": "Drop item when no space"
 }

--- a/projects/1.16/assets/backslot/backslot/lang/zh_cn.json
+++ b/projects/1.16/assets/backslot/backslot/lang/zh_cn.json
@@ -1,4 +1,18 @@
 {
   "key.backslot.switch_backslot": "切换背用武器",
-  "category.backslot.key": "背用武器"
+  "key.backslot.switch_beltslot": "切换皮带武器",
+  "category.backslot.key": "背用武器",
+  "text.autoconfig.backslot.title": "背用武器配置",
+  "text.autoconfig.backslot.category.default": "默认设置",
+  "text.autoconfig.backslot.category.advanced_settings": "高级设置",
+  "text.autoconfig.backslot.option.backslot_scale": "背用武器物品大小",
+  "text.autoconfig.backslot.option.beltslot_scale": "皮带武器物品大小",
+  "text.autoconfig.backslot.option.backslot_sounds": "背用武器声音",
+  "text.autoconfig.backslot.option.change_slot_arrangement": "改变空位排序",
+  "text.autoconfig.backslot.option.disable_backslot_hud": "关闭背用武器HUD",
+  "text.autoconfig.backslot.option.backSlot_x": "背用武器X",
+  "text.autoconfig.backslot.option.backSlot_y": "背用武器Y",
+  "text.autoconfig.backslot.option.beltSlot_x": "皮带武器X",
+  "text.autoconfig.backslot.option.beltSlot_y": "皮带武器Y",
+  "text.autoconfig.backslot.option.backSlot_x.@PrefixText": "物品栏空位位置"
 }

--- a/projects/1.16/assets/backslot/backslot/lang/zh_cn.json
+++ b/projects/1.16/assets/backslot/backslot/lang/zh_cn.json
@@ -1,1 +1,4 @@
-{}
+{
+  "key.backslot.switch_backslot": "切换背用武器",
+  "category.backslot.key": "背用武器"
+}


### PR DESCRIPTION
<!--要勾选下面的复选框 可以将文本[ ]改为[x]-->

- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang`
  - 如果是 1.16 翻译，应该是：`projects/1.16/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
  - 如果是 1.18 翻译，应该是：`projects/1.18/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [x] 刷新 PR 的标签/状态，有需要再点击；
