### PR TITLE
[R] Telepastries 翻译提交

### DIFF
--- a/projects/1.16/assets/telepastries/telepastries/lang/en_us.json
+++ b/projects/1.16/assets/telepastries/telepastries/lang/en_us.json
@@ -1,18 +1,29 @@
 {
-  "_comment": "Config",
-  "telepastries.config.title": "TelePastries config",
-  "itemGroup.tele_tab": "TelePastries",
-  "block.telepastries.nether_cake": "Nether Cake",
-  "block.telepastries.end_cake": "End Cake",
-  "block.telepastries.overworld_cake": "Overworld Cake",
-  "block.telepastries.twilight_cake": "Twilight Cake",
-  "block.telepastries.lost_city_cake": "Lost City Cake",
-  "block.telepastries.hunting_dimension_cake": "Hunting Dimension Cake",
-  "block.telepastries.custom_cake": "%s Cake",
-  "telepastries.pastry.reset.complete": "Dimension %s 's saved position has been reset.",
-  "telepastries.pastry.reset.failed": "Dimension %s does not have a saved position.",
-  "telepastries.pastry.support.disabled": "Cake is disabled because %s isn't installed",
-  "telepastries.pastry.custom.unbound": "Custom Cake has no dimension bound in config ",
-  "telepastries.pastry.custom.invalid": "Destination of cake invalid %s",
-  "telepastries.bites": "Cake bites"
+    "_comment": "Config",
+    "telepastries.config.title": "TelePastries config",
+
+    "_comment": "Creative Tab",
+    "itemGroup.tele_tab": "TelePastries",
+
+    "_comment": "Block",
+    "block.telepastries.nether_cake": "Nether Cake",
+    "block.telepastries.end_cake": "End Cake",
+    "block.telepastries.overworld_cake": "Overworld Cake",
+
+    "block.telepastries.twilight_cake": "Twilight Cake",
+    "block.telepastries.lost_city_cake": "Lost City Cake",
+    "block.telepastries.hunting_dimension_cake": "Hunting Dimension Cake",
+    "block.telepastries.custom_cake": "%s Cake",
+
+    "_comment": "Message",
+    "telepastries.pastry.reset.complete": "Dimension %s 's saved position has been reset.",
+    "telepastries.pastry.reset.failed": "Dimension %s does not have a saved position.",
+    "telepastries.pastry.support.disabled": "Cake is disabled because %s isn't installed",
+    "telepastries.pastry.custom.unbound": "Custom Cake has no dimension bound in config ",
+    "telepastries.pastry.custom.invalid": "Destination of cake invalid %s",
+    "telepastries.same_dimension": "Can't teleport to the same dimension",
+    "telepastries.teleport_restricted": "Can't teleport to a non-overworld dimension",
+
+    "_comment": "Waila",
+    "telepastries.bites": "Cake bites"
 }

--- a/projects/1.16/assets/telepastries/telepastries/lang/zh_cn.json
+++ b/projects/1.16/assets/telepastries/telepastries/lang/zh_cn.json
@@ -1,1 +1,29 @@
-{}
+{
+    "_comment": "Config",
+    "telepastries.config.title": "传送蛋糕配置",
+
+    "_comment": "Creative Tab",
+    "itemGroup.tele_tab": "传送蛋糕",
+
+    "_comment": "Block",
+    "block.telepastries.nether_cake": "下界蛋糕",
+    "block.telepastries.end_cake": "末地蛋糕",
+    "block.telepastries.overworld_cake": "主世界蛋糕",
+
+    "block.telepastries.twilight_cake": "暮色蛋糕",
+    "block.telepastries.lost_city_cake": "失落之城蛋糕",
+    "block.telepastries.hunting_dimension_cake": "狩猎维度蛋糕",
+    "block.telepastries.custom_cake": "%s蛋糕",
+
+    "_comment": "Message",
+    "telepastries.pastry.reset.complete": "%s维度的已存坐标被重置",
+    "telepastries.pastry.reset.failed": "%s维度没有已存坐标",
+    "telepastries.pastry.support.disabled": "%s没有安装，蛋糕不可用",
+    "telepastries.pastry.custom.unbound": "自定义蛋糕在设置中没有维度边界",
+    "telepastries.pastry.custom.invalid": "蛋糕目标不可用 %s",
+    "telepastries.same_dimension": "无法传送到相同维度",
+    "telepastries.teleport_restricted": "无法传送至非主世界维度",
+
+    "_comment": "Waila",
+    "telepastries.bites": "啃蛋糕"
+}

--- a/projects/1.16/assets/telepastries/telepastries/lang/zh_cn.json
+++ b/projects/1.16/assets/telepastries/telepastries/lang/zh_cn.json
@@ -16,14 +16,14 @@
     "block.telepastries.custom_cake": "%s蛋糕",
 
     "_comment": "Message",
-    "telepastries.pastry.reset.complete": "%s维度的已存坐标被重置",
-    "telepastries.pastry.reset.failed": "%s维度没有已存坐标",
+    "telepastries.pastry.reset.complete": "已重置%s维度的存储坐标",
+    "telepastries.pastry.reset.failed": "%s维度没有存储坐标",
     "telepastries.pastry.support.disabled": "%s没有安装，蛋糕不可用",
-    "telepastries.pastry.custom.unbound": "自定义蛋糕在设置中没有维度边界",
-    "telepastries.pastry.custom.invalid": "蛋糕目标不可用 %s",
+    "telepastries.pastry.custom.unbound": "没有在配置中设置自定义蛋糕维度边界",
+    "telepastries.pastry.custom.invalid": "蛋糕目标不可用%s",
     "telepastries.same_dimension": "无法传送到相同维度",
     "telepastries.teleport_restricted": "无法传送至非主世界维度",
 
     "_comment": "Waila",
-    "telepastries.bites": "啃蛋糕"
+    "telepastries.bites": "咬过的蛋糕"
 }


### PR DESCRIPTION
<!--要勾选下面的复选框 可以将文本[ ]改为[x]-->

- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang`
  - 如果是 1.16 翻译，应该是：`projects/1.16/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
  - 如果是 1.18 翻译，应该是：`projects/1.18/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [x] 刷新 PR 的标签/状态，有需要再点击；
