### PR TITLE
[R] Customizable Elytra 翻译提交与英文更正

### DIFF
--- a/projects/1.16/assets/customizable-elytra/customizableelytra/lang/en_us.json
+++ b/projects/1.16/assets/customizable-elytra/customizableelytra/lang/en_us.json
@@ -1,6 +1,23 @@
 {
-  "item.customizable_elytra.cape_hidden": "Cape Pattern Hidden",
-  "item.customizable_elytra.left_wing": "Left Wing:",
-  "item.customizable_elytra.right_wing": "Right Wing:",
-  "item.customizableelytra.elytra_wing": "Elytra Wing"
+  "block.minecraft.banner.base.black": "Black Base",
+  "block.minecraft.banner.base.blue": "Blue Base",
+  "block.minecraft.banner.base.brown": "Brown Base",
+  "block.minecraft.banner.base.cyan": "Cyan Base",
+  "block.minecraft.banner.base.gray": "Gray Base",
+  "block.minecraft.banner.base.green": "Green Base",
+  "block.minecraft.banner.base.light_blue": "Light Blue Base",
+  "block.minecraft.banner.base.light_gray": "Light Gray Base",
+  "block.minecraft.banner.base.lime": "Lime Base",
+  "block.minecraft.banner.base.magenta": "Magenta Base",
+  "block.minecraft.banner.base.orange": "Orange Base",
+  "block.minecraft.banner.base.pink": "Pink Base",
+  "block.minecraft.banner.base.purple": "Purple Base",
+  "block.minecraft.banner.base.red": "Red Base",
+  "block.minecraft.banner.base.white": "White Base",
+  "block.minecraft.banner.base.yellow": "Yellow Base",
+  "item.customizableelytra.cape_hidden": "Cape Pattern Hidden",
+  "item.customizableelytra.elytra_wing": "Elytra Wing",
+  "item.customizableelytra.glowing_wing": "Glowing",
+  "item.customizableelytra.left_wing": "Left Wing:",
+  "item.customizableelytra.right_wing": "Right Wing:"
 }

--- a/projects/1.16/assets/customizable-elytra/customizableelytra/lang/zh_cn.json
+++ b/projects/1.16/assets/customizable-elytra/customizableelytra/lang/zh_cn.json
@@ -1,6 +1,23 @@
 {
-  "item.customizable_elytra.cape_hidden": "披风图案已隐藏",
-  "item.customizable_elytra.left_wing": "左翼：",
-  "item.customizable_elytra.right_wing": "右翼：",
-  "item.customizableelytra.elytra_wing": "鞘翅翅膀"
+  "block.minecraft.banner.base.black": "黑色基底",
+  "block.minecraft.banner.base.blue": "蓝色基底",
+  "block.minecraft.banner.base.brown": "棕色基底",
+  "block.minecraft.banner.base.cyan": "青色基底",
+  "block.minecraft.banner.base.gray": "灰色基底",
+  "block.minecraft.banner.base.green": "绿色基底",
+  "block.minecraft.banner.base.light_blue": "淡蓝色基底",
+  "block.minecraft.banner.base.light_gray": "淡灰色基底",
+  "block.minecraft.banner.base.lime": "黄绿色基底",
+  "block.minecraft.banner.base.magenta": "品红色基底",
+  "block.minecraft.banner.base.orange": "橙色基底",
+  "block.minecraft.banner.base.pink": "粉红色基底",
+  "block.minecraft.banner.base.purple": "紫色基底",
+  "block.minecraft.banner.base.red": "红色基底",
+  "block.minecraft.banner.base.white": "白色基底",
+  "block.minecraft.banner.base.yellow": "黄色基底",
+  "item.customizableelytra.cape_hidden": "披风图案已隐藏",
+  "item.customizableelytra.elytra_wing": "鞘翅翅膀",
+  "item.customizableelytra.glowing_wing": "发光翅膀",
+  "item.customizableelytra.left_wing": "左翼：",
+  "item.customizableelytra.right_wing": "右翼："
 }

--- a/projects/1.16/assets/customizable-elytra/customizableelytra/lang/zh_cn.json
+++ b/projects/1.16/assets/customizable-elytra/customizableelytra/lang/zh_cn.json
@@ -1,1 +1,6 @@
-{}
+{
+  "item.customizable_elytra.cape_hidden": "披风图案已隐藏",
+  "item.customizable_elytra.left_wing": "左翼：",
+  "item.customizable_elytra.right_wing": "右翼：",
+  "item.customizableelytra.elytra_wing": "鞘翅翅膀"
+}


### PR DESCRIPTION
<!--要勾选下面的复选框 可以将文本[ ]改为[x]-->

- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang`
  - 如果是 1.16 翻译，应该是：`projects/1.16/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
  - 如果是 1.18 翻译，应该是：`projects/1.18/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [x] 刷新 PR 的标签/状态，有需要再点击；
