### PR TITLE
[R] Durability Notifier 翻译提交

### DIFF
--- a/projects/1.16/assets/durability-notifier/durabilitynotifier/lang/en_us.json
+++ b/projects/1.16/assets/durability-notifier/durabilitynotifier/lang/en_us.json
@@ -1,7 +1,8 @@
 {
   "_comment": "Config Name",
   "durabilitynotifier.config.title": "Durability Notifier Config",
-  "warning.part1": "Warning! %s",
-  "warning.part2": "has dropped below",
-  "warning.part3": "durability."
+  "_comment": "Warning message",
+  "durabilitynotifier.warning.part1": "Warning! %s",
+  "durabilitynotifier.warning.part2": " has dropped below ",
+  "durabilitynotifier.warning.part3": "durability."
 }

--- a/projects/1.16/assets/durability-notifier/durabilitynotifier/lang/en_us.json
+++ b/projects/1.16/assets/durability-notifier/durabilitynotifier/lang/en_us.json
@@ -1,8 +1,8 @@
 {
-  "_comment": "Config Name",
-  "durabilitynotifier.config.title": "Durability Notifier Config",
-  "_comment": "Warning message",
-  "durabilitynotifier.warning.part1": "Warning! %s",
-  "durabilitynotifier.warning.part2": " has dropped below ",
-  "durabilitynotifier.warning.part3": "durability."
+  "_comment":"Config Name",
+  "durabilitynotifier.config.title":"Durability Notifier Config",
+  "_comment":"Warning message",
+  "durabilitynotifier.warning.part1":"Warning! %s",
+  "durabilitynotifier.warning.part2":" has dropped below ",
+  "durabilitynotifier.warning.part3":"durability."
 }

--- a/projects/1.16/assets/durability-notifier/durabilitynotifier/lang/zh_cn.json
+++ b/projects/1.16/assets/durability-notifier/durabilitynotifier/lang/zh_cn.json
@@ -3,6 +3,6 @@
   "durabilitynotifier.config.title": "耐久度提示器配置",  
   "_comment": "警告信息",
   "durabilitynotifier.warning.part1": "警告！%s",
-  "durabilitynotifier.warning.part2": "已经降到耐久度",
-  "durabilitynotifier.warning.part3": "以下了。"
+  "durabilitynotifier.warning.part2": "已经降到",
+  "durabilitynotifier.warning.part3": "耐久度以下了。"
 }

--- a/projects/1.16/assets/durability-notifier/durabilitynotifier/lang/zh_cn.json
+++ b/projects/1.16/assets/durability-notifier/durabilitynotifier/lang/zh_cn.json
@@ -1,7 +1,8 @@
 {
   "_comment": "配置名称",
-  "durabilitynotifier.config.title": "耐久度提示器配置",
-  "warning.part1": "警告！%s",
-  "warning.part2": "已经降到耐久度",
-  "warning.part3": "以下了。"
+  "durabilitynotifier.config.title": "耐久度提示器配置",  
+  "_comment": "警告信息",
+  "durabilitynotifier.warning.part1": "警告！%s",
+  "durabilitynotifier.warning.part2": "已经降到耐久度",
+  "durabilitynotifier.warning.part3": "以下了。"
 }

--- a/projects/1.16/assets/durability-notifier/durabilitynotifier/lang/zh_cn.json
+++ b/projects/1.16/assets/durability-notifier/durabilitynotifier/lang/zh_cn.json
@@ -1,1 +1,7 @@
-{}
+{
+  "_comment": "配置名称",
+  "durabilitynotifier.config.title": "耐久度提示器配置",
+  "warning.part1": "警告！%s",
+  "warning.part2": "已经降到耐久度",
+  "warning.part3": "以下了。"
+}


### PR DESCRIPTION
<!--要勾选下面的复选框 可以将文本[ ]改为[x]-->

- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：`projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang`
  - 如果是 1.16 翻译，应该是：`projects/1.16/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
  - 如果是 1.18 翻译，应该是：`projects/1.18/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json`
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [x] 刷新 PR 的标签/状态，有需要再点击；
