### PR TITLE
[R] Editsign 翻译提交

### DIFF
--- a/projects/1.16/assets/edit-sign/editsign/lang/zh_cn.json
+++ b/projects/1.16/assets/edit-sign/editsign/lang/zh_cn.json
@@ -3,9 +3,9 @@
   "text.autoconfig.editsign.error.invalidItemResourceLocation": "提供了无效物品，必须拥有以下格式：'mod_id:item_id'",
   "text.autoconfig.editsign.category.default": "总设置",
   "text.autoconfig.editsign.option.requiredItemId": "需要物品ID",
-  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[0]": "用户需要拿着的",
-  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[1]": "物品的ID以编辑",
-  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[2]": "一个告示牌。如果没有设置任何值的话",
+  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[0]": "用户要编辑一个告示牌",
+  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[1]": "需要手持的物品的ID。",
+  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[2]": "如果没有设置任何值的话",
   "text.autoconfig.editsign.option.requiredItemId.@Tooltip[3]": "任何物品都是可以的。",
   "editsign.action.not_editable": "这个告示牌不可编辑"
 }

--- a/projects/1.16/assets/edit-sign/editsign/lang/zh_cn.json
+++ b/projects/1.16/assets/edit-sign/editsign/lang/zh_cn.json
@@ -1,11 +1,11 @@
 {
-  "text.autoconfig.editsign.title": "标志编辑配置",
+  "text.autoconfig.editsign.title": "告示牌编辑配置",
   "text.autoconfig.editsign.error.invalidItemResourceLocation": "提供了无效物品，必须拥有以下格式：'mod_id:item_id'",
   "text.autoconfig.editsign.category.default": "总设置",
   "text.autoconfig.editsign.option.requiredItemId": "需要物品ID",
   "text.autoconfig.editsign.option.requiredItemId.@Tooltip[0]": "用户需要拿着的",
   "text.autoconfig.editsign.option.requiredItemId.@Tooltip[1]": "物品的ID以编辑",
-  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[2]": "一个标志。如果没有设置任何值的话",
+  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[2]": "一个告示牌。如果没有设置任何值的话",
   "text.autoconfig.editsign.option.requiredItemId.@Tooltip[3]": "任何物品都是可以的。",
-  "editsign.action.not_editable": "这个标志不可编辑"
+  "editsign.action.not_editable": "这个告示牌不可编辑"
 }

--- a/projects/1.16/assets/edit-sign/editsign/lang/zh_cn.json
+++ b/projects/1.16/assets/edit-sign/editsign/lang/zh_cn.json
@@ -1,7 +1,7 @@
 {
   "text.autoconfig.editsign.title": "告示牌编辑配置",
   "text.autoconfig.editsign.error.invalidItemResourceLocation": "提供了无效物品，必须拥有以下格式：'mod_id:item_id'",
-  "text.autoconfig.editsign.category.default": "总设置",
+  "text.autoconfig.editsign.category.default": "常规",
   "text.autoconfig.editsign.option.requiredItemId": "需要物品ID",
   "text.autoconfig.editsign.option.requiredItemId.@Tooltip[0]": "用户要编辑一个告示牌",
   "text.autoconfig.editsign.option.requiredItemId.@Tooltip[1]": "需要手持的物品的ID。",

--- a/projects/1.16/assets/edit-sign/editsign/lang/zh_cn.json
+++ b/projects/1.16/assets/edit-sign/editsign/lang/zh_cn.json
@@ -1,1 +1,11 @@
-{}
+{
+  "text.autoconfig.editsign.title": "标志编辑配置",
+  "text.autoconfig.editsign.error.invalidItemResourceLocation": "提供了无效物品，必须拥有以下格式：'mod_id:item_id'",
+  "text.autoconfig.editsign.category.default": "总设置",
+  "text.autoconfig.editsign.option.requiredItemId": "需要物品ID",
+  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[0]": "用户需要拿着的",
+  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[1]": "物品的ID以编辑",
+  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[2]": "一个标志。如果没有设置任何值的话",
+  "text.autoconfig.editsign.option.requiredItemId.@Tooltip[3]": "任何物品都是可以的。",
+  "editsign.action.not_editable": "这个标志不可编辑"
+}


### PR DESCRIPTION
<!--要勾选下面的复选框 可以将文本[ ]改为[x]-->

- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：projects/1.12/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang
  - 如果是 1.16 及以上的翻译，应该是：projects/{版本}/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [x] 刷新 PR 的标签/状态，有需要再点击；
