### PR TITLE
[R] 修改Scape and Run: Parasites的模组译名

### DIFF
--- a/projects/1.12.2/assets/scape-and-run-parasites/srparasites/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/scape-and-run-parasites/srparasites/lang/zh_cn.lang
@@ -73,7 +73,7 @@ entity.srparasites.ada_arachnida.name=适应蛛形兽
 
 #Creative Tab
 
-itemGroup.SRParasites=逃逸：寄生兽
+itemGroup.SRParasites=逃逸：寄生体
 
 #Items
 


### PR DESCRIPTION
<!--要勾选下面的复选框 可以将文本[ ]改为[x]-->

- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：projects/1.12/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang
  - 如果是 1.16 及以上的翻译，应该是：projects/{版本}/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [ ] 刷新 PR 的标签/状态，有需要再点击；

- 修改说明
  只是把“逃逸：寄生兽”改为“逃逸：寄生体”，未作其他改动；
  修改原因为“逃逸：寄生兽”中的“寄生兽”这个词，避免与有一定知名度日本漫改作品《寄生兽》的名字以及内容产生社交上的冲 
  突与麻烦；
  据我收集双方的相关资料来看，也否定了《寄生兽》目前与本模组联动的可能性，curseforge页面作者留下的信息也没有与之的 
  相关性，全是关于模组内容的讨论与更新内容，并且模组内容也与漫改作品《寄生兽》的内容大相径庭；
  并且在google翻译以及百度翻译等翻译软件上用“寄生体，寄生生物，寄生虫，寄生植物”所翻译的英文都只有Parasite或 
  Parasites与模组英文名相近的一个词语，而使用“寄生兽”则是“parasitic beast”或“Parasitic animal”与模组英文名有一定区别的一 
  个词组，并且parasitic beast是漫改作品《寄生兽》在百科上所编写的英文名称；
  基于以上因素考虑，决定修改模组译名“逃逸：寄生兽”为“逃逸：寄生体”去规避可能出现的风险

- 模组作者的FAQ地址：https://docs.google.com/document/d/13_IO_WqngGOwnk44lIsznwsRpH-fhdi52crjJmh1Fu4/edit#
- 模组发布的curseforge地址：https://www.curseforge.com/minecraft/mc-mods/scape-and-run-parasites
