### PR TITLE
[R] Sushimod 与 Automated crafting 模组翻译

### DIFF
--- a/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
+++ b/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
@@ -8,7 +8,7 @@
   "text.autoconfig.automated_crafting.option.quasiConnectivity.@Tooltip": "如果在自动化工作台上方的方块被充能，那么自动化工作台将会被充能（而不是更新）",
   "text.autoconfig.automated_crafting.option.redirectsRedstone": "启用红石粉重定向",
   "text.autoconfig.automated_crafting.option.redirectsRedstone.@Tooltip": "在自动化工作台旁的红石粉将会指向自动化工作台",
-  "text.autoconfig.automated_crafting.option.": "被充能时无间歇合成",
+  "text.autoconfig.automated_crafting.option.craftContinuously": "被充能时无间歇合成",
   "text.autoconfig.automated_crafting.option.craftContinuously.@Tooltip": "如果自动化工作台被充能，且包含一个有效的配方时，那么工作台会立即合成那个配方",
   "text.autoconfig.automated_crafting.option.comparatorReadsOutput": "当输出不为空时，红石比较器将会输出强度为15的信号",
   "text.autoconfig.automated_crafting.option.comparatorReadsOutput.@Tooltip": "如果红石比较器用任何在工作台输出中的物品来读取工作台，那么比较器会输出强度为15的信号",

--- a/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
+++ b/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
@@ -10,7 +10,7 @@
   "text.autoconfig.automated_crafting.option.redirectsRedstone.@Tooltip": "在自动化工作台旁的红石粉将会指向自动化工作台",
   "text.autoconfig.automated_crafting.option.craftContinuously": "被充能时无间歇合成",
   "text.autoconfig.automated_crafting.option.craftContinuously.@Tooltip": "如果自动化工作台被充能，且包含一个有效的配方时，那么工作台会立即合成那个配方",
-  "text.autoconfig.automated_crafting.option.comparatorReadsOutput": "当输出不为空时，红石比较器将会输出强度为15的信号",
+  "text.autoconfig.automated_crafting.option.comparatorReadsOutput": "当输出槽不为空时，红石比较器将会输出强度为15的信号",
   "text.autoconfig.automated_crafting.option.comparatorReadsOutput.@Tooltip": "如果红石比较器用任何在工作台输出中的物品来读取工作台，那么比较器会输出强度为15的信号",
   "label.automated_crafting.template": "模版",
   "label.automated_crafting.input": "输入"

--- a/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
+++ b/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
@@ -11,7 +11,7 @@
   "text.autoconfig.automated_crafting.option.craftContinuously": "被充能时无间歇合成",
   "text.autoconfig.automated_crafting.option.craftContinuously.@Tooltip": "自动化工作台被充能，且包含一个有效的配方时，会立即合成那个配方",
   "text.autoconfig.automated_crafting.option.comparatorReadsOutput": "当输出槽不为空时，红石比较器将会输出强度为15的信号",
-  "text.autoconfig.automated_crafting.option.comparatorReadsOutput.@Tooltip": "如果红石比较器用任何在工作台输出中的物品来读取工作台，那么比较器会输出强度为15的信号",
+  "text.autoconfig.automated_crafting.option.comparatorReadsOutput.@Tooltip": "当自动化工作台中有任何物品时比较器将输出强度15的红石信号",
   "label.automated_crafting.template": "模板",
   "label.automated_crafting.input": "输入"
 }

--- a/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
+++ b/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
@@ -1,1 +1,17 @@
-{}
+{
+  "text.autoconfig.automated_crafting.title": "自动化合成设置",
+  "item.automated_crafting.auto_crafter": "自动化工作台",
+  "block.automated_crafting.auto_crafter": "自动化工作台",
+  "text.autoconfig.automated_crafting.option.simpleMode": "启用简单模式",
+  "text.autoconfig.automated_crafting.option.simpleMode.@Tooltip": "在简单模式中，你可以设置一个配方模版",
+  "text.autoconfig.automated_crafting.option.quasiConnectivity": "启用半连接",
+  "text.autoconfig.automated_crafting.option.quasiConnectivity.@Tooltip": "如果在自动化工作台上方的方块被充能，那么自动化工作台将会被充能（而不是更新）",
+  "text.autoconfig.automated_crafting.option.redirectsRedstone": "启用红石粉重定向",
+  "text.autoconfig.automated_crafting.option.redirectsRedstone.@Tooltip": "在自动化工作台旁的红石粉将会指向自动化工作台",
+  "text.autoconfig.automated_crafting.option.": "被充能时无间歇合成",
+  "text.autoconfig.automated_crafting.option.craftContinuously.@Tooltip": "如果自动化工作台被充能，且包含一个有效的配方时，那么工作台会立即合成那个配方",
+  "text.autoconfig.automated_crafting.option.comparatorReadsOutput": "当输出不为空时，红石比较器将会输出强度为15的信号",
+  "text.autoconfig.automated_crafting.option.comparatorReadsOutput.@Tooltip": "如果红石比较器用任何在工作台输出中的物品来读取工作台，那么比较器会输出强度为15的信号",
+  "label.automated_crafting.template": "模版",
+  "label.automated_crafting.input": "输入"
+}

--- a/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
+++ b/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
@@ -9,7 +9,7 @@
   "text.autoconfig.automated_crafting.option.redirectsRedstone": "启用红石粉重定向",
   "text.autoconfig.automated_crafting.option.redirectsRedstone.@Tooltip": "在自动化工作台旁的红石粉将会指向自动化工作台",
   "text.autoconfig.automated_crafting.option.craftContinuously": "被充能时无间歇合成",
-  "text.autoconfig.automated_crafting.option.craftContinuously.@Tooltip": "如果自动化工作台被充能，且包含一个有效的配方时，那么工作台会立即合成那个配方",
+  "text.autoconfig.automated_crafting.option.craftContinuously.@Tooltip": "自动化工作台被充能，且包含一个有效的配方时，会立即合成那个配方",
   "text.autoconfig.automated_crafting.option.comparatorReadsOutput": "当输出槽不为空时，红石比较器将会输出强度为15的信号",
   "text.autoconfig.automated_crafting.option.comparatorReadsOutput.@Tooltip": "如果红石比较器用任何在工作台输出中的物品来读取工作台，那么比较器会输出强度为15的信号",
   "label.automated_crafting.template": "模板",

--- a/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
+++ b/projects/1.18-fabric/assets/automated-crafting/automated_crafting/lang/zh_cn.json
@@ -12,6 +12,6 @@
   "text.autoconfig.automated_crafting.option.craftContinuously.@Tooltip": "如果自动化工作台被充能，且包含一个有效的配方时，那么工作台会立即合成那个配方",
   "text.autoconfig.automated_crafting.option.comparatorReadsOutput": "当输出槽不为空时，红石比较器将会输出强度为15的信号",
   "text.autoconfig.automated_crafting.option.comparatorReadsOutput.@Tooltip": "如果红石比较器用任何在工作台输出中的物品来读取工作台，那么比较器会输出强度为15的信号",
-  "label.automated_crafting.template": "模版",
+  "label.automated_crafting.template": "模板",
   "label.automated_crafting.input": "输入"
 }

--- a/projects/1.18-fabric/assets/exlines-sushi-mod/sushimod/lang/zh_cn.json
+++ b/projects/1.18-fabric/assets/exlines-sushi-mod/sushimod/lang/zh_cn.json
@@ -1,1 +1,23 @@
-{}
+{
+  "itemGroup.sushimod.foods": "寿司和刺身",
+  "item.sushimod.cucumber": "黄瓜",
+  "item.sushimod.cucumber_seeds": "黄瓜种子",
+  "item.sushimod.calamari_roll": "鱿鱼卷",
+  "item.sushimod.calamari_sashimi": "鱿鱼刺身",
+  "item.sushimod.clownfish_roll": "小丑鱼卷",
+  "item.sushimod.clownfish_sashimi": "尼莫鱼卷",
+  "item.sushimod.cooked_calamari": "熟鱿鱼",
+  "item.sushimod.cucumber_roll": "黄瓜卷",
+  "item.sushimod.fish_roll": "鱼卷",
+  "item.sushimod.mushroom_roll": "蘑菇卷",
+  "item.sushimod.nori": "紫菜",
+  "item.sushimod.pufferfish_roll": "河豚卷",
+  "item.sushimod.rainbow_roll": "彩虹卷",
+  "item.sushimod.raw_calamari": "生鱿鱼",
+  "item.sushimod.rice": "熟米饭",
+  "item.sushimod.rice_ball": "饭团",
+  "item.sushimod.rice_seeds": "稻种",
+  "item.sushimod.salmon_roll": "鲑鱼卷",
+  "item.sushimod.salmon_sashimi": "鲑鱼刺身",
+  "item.sushimod.sashimi": "鲑鱼"
+}

--- a/projects/1.18-fabric/assets/exlines-sushi-mod/sushimod/lang/zh_cn.json
+++ b/projects/1.18-fabric/assets/exlines-sushi-mod/sushimod/lang/zh_cn.json
@@ -5,7 +5,7 @@
   "item.sushimod.calamari_roll": "鱿鱼卷",
   "item.sushimod.calamari_sashimi": "鱿鱼刺身",
   "item.sushimod.clownfish_roll": "小丑鱼卷",
-  "item.sushimod.clownfish_sashimi": "小丑鱼刺身",
+  "item.sushimod.clownfish_sashimi": "尼莫刺身",
   "item.sushimod.cooked_calamari": "熟鱿鱼",
   "item.sushimod.cucumber_roll": "黄瓜卷",
   "item.sushimod.fish_roll": "鱼卷",

--- a/projects/1.18-fabric/assets/exlines-sushi-mod/sushimod/lang/zh_cn.json
+++ b/projects/1.18-fabric/assets/exlines-sushi-mod/sushimod/lang/zh_cn.json
@@ -19,5 +19,5 @@
   "item.sushimod.rice_seeds": "稻种",
   "item.sushimod.salmon_roll": "鲑鱼卷",
   "item.sushimod.salmon_sashimi": "鲑鱼刺身",
-  "item.sushimod.sashimi": "鲑鱼"
+  "item.sushimod.sashimi": "刺身"
 }

--- a/projects/1.18-fabric/assets/exlines-sushi-mod/sushimod/lang/zh_cn.json
+++ b/projects/1.18-fabric/assets/exlines-sushi-mod/sushimod/lang/zh_cn.json
@@ -5,7 +5,7 @@
   "item.sushimod.calamari_roll": "鱿鱼卷",
   "item.sushimod.calamari_sashimi": "鱿鱼刺身",
   "item.sushimod.clownfish_roll": "小丑鱼卷",
-  "item.sushimod.clownfish_sashimi": "尼莫鱼卷",
+  "item.sushimod.clownfish_sashimi": "小丑鱼刺身",
   "item.sushimod.cooked_calamari": "熟鱿鱼",
   "item.sushimod.cucumber_roll": "黄瓜卷",
   "item.sushimod.fish_roll": "鱼卷",


### PR DESCRIPTION
<!--要勾选下面的复选框 可以将文本[ ]改为[x]-->

- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：projects/1.12/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang
  - 如果是 1.16 及以上的翻译，应该是：projects/{版本}/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [ ] 刷新 PR 的标签/状态，有需要再点击；
