### PR TITLE
[R] fix #1898 lycanitesmobs 导致原版条件下显示错误

### DIFF
--- a/projects/1.12.2/assets/lycanites-mobs/lycanitesmobs/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/lycanites-mobs/lycanitesmobs/lang/zh_cn.lang
@@ -60,9 +60,11 @@ subspecies.sand.name=沙化
 #
 #
 # ========== Items ==========
-item.horsearmormetal.name=铁宠物盔甲
-item.horsearmorgold.name=金宠物盔甲
-item.horsearmordiamond.name=钻石宠物盔甲
+# see https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/1898
+#item.horsearmormetal.name=铁宠物盔甲
+#item.horsearmorgold.name=金宠物盔甲
+#item.horsearmordiamond.name=钻石宠物盔甲
+
 item.lycanitesmobs.charge=能量球
 item.lycanitesmobs.charge.description=充能的元素能量球。可用于升级与之相匹配的宠物和装备，也可以从发射器里被发射或者潜行时丢出。
 item.lycanitesmobs.charge.projectile=弹射物：


### PR DESCRIPTION
<!--要勾选下面的复选框 可以将文本[ ]改为[x]-->

- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：projects/1.12/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang
  - 如果是 1.16 及以上的翻译，应该是：projects/{版本}/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [ ] 刷新 PR 的标签/状态，有需要再点击；

close #1898 