### PR TITLE
修复简单农业模组`sprinkles`翻译错误

### DIFF
--- a/projects/1.16/assets/simple-farming/simplefarming/lang/zh_cn.json
+++ b/projects/1.16/assets/simple-farming/simplefarming/lang/zh_cn.json
@@ -282,7 +282,7 @@
   "block.simplefarming.marshmallow": "药蜀葵",
   "block.simplefarming.chicory": "菊苣",
   "block.simplefarming.grape_leaves_base": "葡萄叶",
-  "item.simplefarming.sprinkles": "气泡水",
+  "item.simplefarming.sprinkles": "彩针糖",
   "advancements.simplefarming.root.description": "在多样的食物中作出选择！",
   "advancements.simplefarming.berries.title": "浆果，棒！",
   "advancements.simplefarming.berries.description": "收集所有野生浆果变种",

--- a/projects/1.18/assets/simple-farming/simplefarming/lang/zh_cn.json
+++ b/projects/1.18/assets/simple-farming/simplefarming/lang/zh_cn.json
@@ -20,7 +20,7 @@
   "advancements.simplefarming.berries.title": "浆果，棒！",
   "advancements.simplefarming.root.description": "在多样的食物中作出选择！",
   "item.simplefarming.veggie_burger": "蔬菜汉堡",
-  "item.simplefarming.sprinkles": "气泡水",
+  "item.simplefarming.sprinkles": "彩针糖",
   "block.simplefarming.grape_leaves_base": "葡萄叶",
   "block.simplefarming.chicory": "菊苣",
   "block.simplefarming.marshmallow": "药蜀葵",


### PR DESCRIPTION
<!--要勾选下面的复选框 可以将文本[ ]改为[x]-->
该错误翻译提交于2020年11月15日 f0c122c37fda4170942ba11c167c62f62ec1cf55
# 错误信息
## 译名
![image](https://user-images.githubusercontent.com/37402126/165894646-a5ee0334-a909-49a2-a0a0-ceefa42327d5.png)
## MC百科
![image](https://user-images.githubusercontent.com/37402126/165895047-e7f280f7-a289-4f44-bfc3-3666fe6eef07.png)
# 翻译依据
## 合成表
![image](https://user-images.githubusercontent.com/37402126/165894666-c420c3ad-2882-4cf7-b923-ca309d42bafc.png)
## 用途
## 牛津词典
![image](https://user-images.githubusercontent.com/37402126/165895087-7318bd18-ee30-4dd0-acbc-1f93e33d3df5.png)
## 现实物品
![image](https://user-images.githubusercontent.com/37402126/165894708-ab266377-76c9-43a8-a888-dc5bc81c74df.png)
## 谷歌名称
![image](https://user-images.githubusercontent.com/37402126/165894731-0769d229-75ca-4242-afde-a2609cf83cba.png)

- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：projects/1.12/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang
  - 如果是 1.16 及以上的翻译，应该是：projects/{版本}/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [ ] 刷新 PR 的标签/状态，有需要再点击；
