### PR TITLE
[R] MaLiLib 翻译更新

### DIFF
--- a/projects/1.16-fabric/assets/malilib/malilib/lang/en_us.json
+++ b/projects/1.16-fabric/assets/malilib/malilib/lang/en_us.json
@@ -6,29 +6,37 @@
   "malilib.config.comment.keybind_settings.context": "Can the keybind be activated in-game or inside a GUI",
   "malilib.config.comment.keybind_settings.exclusive": "If true, then no other keybinds can have\nbeen activated before the keybind in question.\nThis check resets when all keys are released.",
   "malilib.config.comment.keybind_settings.order_sensitive": "Should the keybind keys be pressed\nin the specific order they were defined in",
+
   "malilib.error.failed_to_create_directory": "Failed to create directory '%s'",
   "malilib.error.file_or_directory_already_exists": "File or directory '%s' already exists",
   "malilib.error.invalid_directory": "Invalid directory name '%s'",
   "malilib.error.invalid_block_blacklist_entry": "Invalid block in a black- or whitelist: '%s'",
   "malilib.error.invalid_item_blacklist_entry": "Invalid item name in a black- or whitelist: '%s'",
+
   "malilib.gui.button.cancel": "Cancel",
   "malilib.gui.button.ok": "OK",
   "malilib.gui.button.reset": "Reset",
   "malilib.gui.button.reset.caps": "RESET",
+
   "malilib.gui.button.render_layers_gui.axis": "Axis: %s",
   "malilib.gui.button.render_layers_gui.layers": "Layers: %s",
   "malilib.gui.button.render_layers_gui.set_here": "Set Here",
+
   "malilib.gui.button.hover.directory_widget.create_directory": "Create a new directory",
   "malilib.gui.button.hover.directory_widget.root": "To root/base directory",
   "malilib.gui.button.hover.directory_widget.up": "Up to parent directory",
   "malilib.gui.button.hover.hold_shift_for_info": "§oHold Shift for more information§r",
   "malilib.gui.button.hover.plus_minus_tip": "Left click to increase\nRight click to decrease\nShift and/or Alt to increase the step size",
+
   "malilib.gui.label.block_snap.center": "Center",
   "malilib.gui.label.block_snap.corner": "Corner",
   "malilib.gui.label.block_snap.none": "None",
+
   "malilib.gui.label_colored.off": "§cOFF§r",
   "malilib.gui.label_colored.on": "§aON§r",
+
   "malilib.gui.label.color_editor.current_color": "Current color:",
+
   "malilib.gui.label.keybind_settings.activate_on": "Activate On",
   "malilib.gui.label.keybind_settings.allow_empty_keybind": "Allow empty keybind",
   "malilib.gui.label.keybind_settings.allow_extra_keys": "Allow extra keys",
@@ -38,16 +46,20 @@
   "malilib.gui.label.keybind_settings.order_sensitive": "Order Sensitive",
   "malilib.gui.label.keybind_settings.tips": "- Left click to configure\n- Right click to reset to defaults",
   "malilib.gui.label.keybind_settings.title_advanced_keybind_settings": "Advanced Keybind settings",
+
   "malilib.gui.label.layer_mode.all": "All",
   "malilib.gui.label.layer_mode.all_above": "All above",
   "malilib.gui.label.layer_mode.all_below": "All below",
   "malilib.gui.label.layer_mode.layer_range": "Layer Range",
   "malilib.gui.label.layer_mode.single_layer": "Single Layer",
+
   "malilib.gui.label.no": "no",
   "malilib.gui.label.yes": "yes",
+
   "malilib.gui.label.render_layers.layer": "Layer",
   "malilib.gui.label.render_layers.layer_max": "Max layer",
   "malilib.gui.label.render_layers.layer_min": "Min layer",
+
   "malilib.gui.title.all_hotkeys": "All registered hotkeys",
   "malilib.gui.title.color_editor": "Color Editor",
   "malilib.gui.title.configs": "malilib Configs",
@@ -56,31 +68,39 @@
   "malilib.gui.title.generic": "Generic",
   "malilib.gui.title.keybind_settings.advanced": "Advanced Keybind Settings for %s",
   "malilib.gui.title.string_list_edit": "Edit string list for '%s'",
+
   "malilib.label.active_mode.always": "Always",
   "malilib.label.active_mode.never": "Never",
   "malilib.label.active_mode.with_key": "With Key",
+
   "malilib.label.key_action.both": "BOTH",
   "malilib.label.key_action.press": "PRESS",
   "malilib.label.key_action.release": "RELEASE",
+
   "malilib.label.key_context.any": "Any",
   "malilib.label.key_context.gui": "GUI",
   "malilib.label.key_context.ingame": "In-Game",
+
   "malilib.label.list_type.blacklist": "Black List",
   "malilib.label.list_type.none": "None",
   "malilib.label.list_type.whitelist": "White List",
+
   "malilib.label.alignment.top_left": "Top Left",
   "malilib.label.alignment.top_right": "Top Right",
   "malilib.label.alignment.bottom_left": "Bottom Left",
   "malilib.label.alignment.bottom_right": "Bottom Right",
   "malilib.label.alignment.center": "Center",
+
   "malilib.message.directory_created": "Directory '%s' created",
   "malilib.message.toggled": "Toggled %s %s",
   "malilib.message.value.off": "OFF",
   "malilib.message.value.on": "ON",
+
   "malilib.message.formatting_code.error": "§c",
   "malilib.message.formatting_code.info": "§f",
   "malilib.message.formatting_code.success": "§a",
   "malilib.message.formatting_code.warning": "§6",
+
   "malilib.message.layer_range.range_max": "max",
   "malilib.message.layer_range.range_min": "min",
   "malilib.message.moved_layer_range": "Moved the entire layer range by §a%s§r on the §a%s§r axis",

--- a/projects/1.16-fabric/assets/malilib/malilib/lang/zh_cn.json
+++ b/projects/1.16-fabric/assets/malilib/malilib/lang/zh_cn.json
@@ -6,29 +6,37 @@
   "malilib.config.comment.keybind_settings.context": "绑定的按键可以在游戏中或GUI中激活吗",
   "malilib.config.comment.keybind_settings.exclusive": "如果为真，则此按键为第一顺位激活的绑定按键\n当其他按键被释放后，该按键将重置",
   "malilib.config.comment.keybind_settings.order_sensitive": "绑定的按键需要按照设置的特定顺序按下吗？",
+
   "malilib.error.failed_to_create_directory": "创建'%s'目录失败",
   "malilib.error.file_or_directory_already_exists": "'%s'文件或目录已经存在",
   "malilib.error.invalid_directory": "无效的目录名称：'%s'",
   "malilib.error.invalid_block_blacklist_entry": "黑名单或白名单中的无效方块: '%s'",
   "malilib.error.invalid_item_blacklist_entry": "黑名单或白名单中无效的物品名称: '%s'",
+
   "malilib.gui.button.cancel": "取消",
   "malilib.gui.button.ok": "确定",
   "malilib.gui.button.reset": "重置",
   "malilib.gui.button.reset.caps": "重置",
+
   "malilib.gui.button.render_layers_gui.axis": "轴: %s",
   "malilib.gui.button.render_layers_gui.layers": "显示层: %s",
   "malilib.gui.button.render_layers_gui.set_here": "设置到玩家位置",
+
   "malilib.gui.button.hover.directory_widget.create_directory": "创建一个新目录",
   "malilib.gui.button.hover.directory_widget.root": "切换到根目录/基本目录",
   "malilib.gui.button.hover.directory_widget.up": "切换到父目录",
   "malilib.gui.button.hover.hold_shift_for_info": "§o按住Shift键可获得更多信息§r",
   "malilib.gui.button.hover.plus_minus_tip": "左键单击以增大\n右击以减小\nShift或Alt增大尺寸",
+
   "malilib.gui.label.block_snap.center": "中心",
   "malilib.gui.label.block_snap.corner": "角",
   "malilib.gui.label.block_snap.none": "无",
+
   "malilib.gui.label_colored.off": "§c关闭§r",
   "malilib.gui.label_colored.on": "§a开启§r",
+
   "malilib.gui.label.color_editor.current_color": "当前颜色:",
+
   "malilib.gui.label.keybind_settings.activate_on": "开启",
   "malilib.gui.label.keybind_settings.allow_empty_keybind": "允许绑定按键为空",
   "malilib.gui.label.keybind_settings.allow_extra_keys": "允许额外绑定按键",
@@ -38,16 +46,20 @@
   "malilib.gui.label.keybind_settings.order_sensitive": "需求顺序",
   "malilib.gui.label.keybind_settings.tips": "-左键设置 \n-右键重置为默认值",
   "malilib.gui.label.keybind_settings.title_advanced_keybind_settings": "高级键绑定设置",
+
   "malilib.gui.label.layer_mode.all": "显示所有",
   "malilib.gui.label.layer_mode.all_above": "以上所有层",
   "malilib.gui.label.layer_mode.all_below": "以下所有层",
   "malilib.gui.label.layer_mode.layer_range": "之间所有层",
   "malilib.gui.label.layer_mode.single_layer": "单层",
+
   "malilib.gui.label.no": "否",
   "malilib.gui.label.yes": "是",
+
   "malilib.gui.label.render_layers.layer": "层数",
   "malilib.gui.label.render_layers.layer_max": "最大层",
   "malilib.gui.label.render_layers.layer_min": "最小层",
+
   "malilib.gui.title.all_hotkeys": "所有注册的热键",
   "malilib.gui.title.color_editor": "颜色编辑",
   "malilib.gui.title.configs": "malilib 配置",
@@ -56,31 +68,39 @@
   "malilib.gui.title.generic": "通用",
   "malilib.gui.title.keybind_settings.advanced": "高级快捷键绑定设置 %s",
   "malilib.gui.title.string_list_edit": "编辑'%s'的字符串列表",
+
   "malilib.label.active_mode.always": "总是",
   "malilib.label.active_mode.never": "决不",
   "malilib.label.active_mode.with_key": "需要按键",
+
   "malilib.label.key_action.both": "两者都",
   "malilib.label.key_action.press": "按下",
   "malilib.label.key_action.release": "释放",
+
   "malilib.label.key_context.any": "任何",
   "malilib.label.key_context.gui": "界面内",
   "malilib.label.key_context.ingame": "游戏内",
+
   "malilib.label.list_type.blacklist": "黑名单",
   "malilib.label.list_type.none": "无",
   "malilib.label.list_type.whitelist": "白名单",
+
   "malilib.label.alignment.top_left": "左上角",
   "malilib.label.alignment.top_right": "右上角",
   "malilib.label.alignment.bottom_left": "左下角",
   "malilib.label.alignment.bottom_right": "右下角",
   "malilib.label.alignment.center": "中间",
+
   "malilib.message.directory_created": "已创建'%s'目录",
   "malilib.message.toggled": "%s 已%s",
   "malilib.message.value.off": "关闭",
   "malilib.message.value.on": "打开",
+
   "malilib.message.formatting_code.error": "§c",
   "malilib.message.formatting_code.info": "§f",
   "malilib.message.formatting_code.success": "§a",
   "malilib.message.formatting_code.warning": "§6",
+
   "malilib.message.layer_range.range_max": "最大",
   "malilib.message.layer_range.range_min": "最小",
   "malilib.message.moved_layer_range": "整体移动 by §a%s§r on the §a%s§r axis",

--- a/projects/1.18-fabric/assets/malilib/malilib/lang/en_us.json
+++ b/projects/1.18-fabric/assets/malilib/malilib/lang/en_us.json
@@ -6,29 +6,37 @@
   "malilib.config.comment.keybind_settings.context": "Can the keybind be activated in-game or inside a GUI",
   "malilib.config.comment.keybind_settings.exclusive": "If true, then no other keybinds can have\nbeen activated before the keybind in question.\nThis check resets when all keys are released.",
   "malilib.config.comment.keybind_settings.order_sensitive": "Should the keybind keys be pressed\nin the specific order they were defined in",
+
   "malilib.error.failed_to_create_directory": "Failed to create directory '%s'",
   "malilib.error.file_or_directory_already_exists": "File or directory '%s' already exists",
   "malilib.error.invalid_directory": "Invalid directory name '%s'",
   "malilib.error.invalid_block_blacklist_entry": "Invalid block in a black- or whitelist: '%s'",
   "malilib.error.invalid_item_blacklist_entry": "Invalid item name in a black- or whitelist: '%s'",
+
   "malilib.gui.button.cancel": "Cancel",
   "malilib.gui.button.ok": "OK",
   "malilib.gui.button.reset": "Reset",
   "malilib.gui.button.reset.caps": "RESET",
+
   "malilib.gui.button.render_layers_gui.axis": "Axis: %s",
   "malilib.gui.button.render_layers_gui.layers": "Layers: %s",
   "malilib.gui.button.render_layers_gui.set_here": "Set Here",
+
   "malilib.gui.button.hover.directory_widget.create_directory": "Create a new directory",
   "malilib.gui.button.hover.directory_widget.root": "To root/base directory",
   "malilib.gui.button.hover.directory_widget.up": "Up to parent directory",
   "malilib.gui.button.hover.hold_shift_for_info": "§oHold Shift for more information§r",
   "malilib.gui.button.hover.plus_minus_tip": "Left click to increase\nRight click to decrease\nShift and/or Alt to increase the step size",
+
   "malilib.gui.label.block_snap.center": "Center",
   "malilib.gui.label.block_snap.corner": "Corner",
   "malilib.gui.label.block_snap.none": "None",
+
   "malilib.gui.label_colored.off": "§cOFF§r",
   "malilib.gui.label_colored.on": "§aON§r",
+
   "malilib.gui.label.color_editor.current_color": "Current color:",
+
   "malilib.gui.label.keybind_settings.activate_on": "Activate On",
   "malilib.gui.label.keybind_settings.allow_empty_keybind": "Allow empty keybind",
   "malilib.gui.label.keybind_settings.allow_extra_keys": "Allow extra keys",
@@ -38,19 +46,24 @@
   "malilib.gui.label.keybind_settings.order_sensitive": "Order Sensitive",
   "malilib.gui.label.keybind_settings.tips": "- Left click to configure\n- Right click to reset to defaults",
   "malilib.gui.label.keybind_settings.title_advanced_keybind_settings": "Advanced Keybind settings",
+
   "malilib.gui.label.layer_mode.all": "All",
   "malilib.gui.label.layer_mode.all_above": "All above",
   "malilib.gui.label.layer_mode.all_below": "All below",
   "malilib.gui.label.layer_mode.layer_range": "Layer Range",
   "malilib.gui.label.layer_mode.single_layer": "Single Layer",
+
   "malilib.label.message_output_type.none": "None",
   "malilib.label.message_output_type.actionbar": "Actionbar",
   "malilib.label.message_output_type.message": "Message",
+
   "malilib.gui.label.no": "no",
   "malilib.gui.label.yes": "yes",
+
   "malilib.gui.label.render_layers.layer": "Layer",
   "malilib.gui.label.render_layers.layer_max": "Max layer",
   "malilib.gui.label.render_layers.layer_min": "Min layer",
+
   "malilib.gui.title.all_hotkeys": "All registered hotkeys",
   "malilib.gui.title.color_editor": "Color Editor",
   "malilib.gui.title.configs": "malilib Configs",
@@ -59,32 +72,40 @@
   "malilib.gui.title.generic": "Generic",
   "malilib.gui.title.keybind_settings.advanced": "Advanced Keybind Settings for %s",
   "malilib.gui.title.string_list_edit": "Edit string list for '%s'",
+
   "malilib.hover.color_indicator.open_color_editor": "Open Color Editor",
   "malilib.label.active_mode.always": "Always",
   "malilib.label.active_mode.never": "Never",
   "malilib.label.active_mode.with_key": "With Key",
+
   "malilib.label.key_action.both": "BOTH",
   "malilib.label.key_action.press": "PRESS",
   "malilib.label.key_action.release": "RELEASE",
+
   "malilib.label.key_context.any": "Any",
   "malilib.label.key_context.gui": "GUI",
   "malilib.label.key_context.ingame": "In-Game",
+
   "malilib.label.list_type.blacklist": "Black List",
   "malilib.label.list_type.none": "None",
   "malilib.label.list_type.whitelist": "White List",
+
   "malilib.label.alignment.top_left": "Top Left",
   "malilib.label.alignment.top_right": "Top Right",
   "malilib.label.alignment.bottom_left": "Bottom Left",
   "malilib.label.alignment.bottom_right": "Bottom Right",
   "malilib.label.alignment.center": "Center",
+
   "malilib.message.directory_created": "Directory '%s' created",
   "malilib.message.toggled": "Toggled %s %s",
   "malilib.message.value.off": "OFF",
   "malilib.message.value.on": "ON",
+
   "malilib.message.formatting_code.error": "§c",
   "malilib.message.formatting_code.info": "§f",
   "malilib.message.formatting_code.success": "§a",
   "malilib.message.formatting_code.warning": "§6",
+
   "malilib.message.layer_range.range_max": "max",
   "malilib.message.layer_range.range_min": "min",
   "malilib.message.moved_layer_range": "Moved the entire layer range by §a%s§r on the §a%s§r axis",

--- a/projects/1.18-fabric/assets/malilib/malilib/lang/zh_cn.json
+++ b/projects/1.18-fabric/assets/malilib/malilib/lang/zh_cn.json
@@ -6,29 +6,37 @@
   "malilib.config.comment.keybind_settings.context": "绑定的按键可以在游戏中或GUI中激活吗",
   "malilib.config.comment.keybind_settings.exclusive": "如果为真，则此按键为第一顺位激活的绑定按键\n当其他按键被释放后，该按键将重置",
   "malilib.config.comment.keybind_settings.order_sensitive": "绑定的按键需要按照设置的特定顺序按下吗？",
+
   "malilib.error.failed_to_create_directory": "创建'%s'目录失败",
   "malilib.error.file_or_directory_already_exists": "'%s'文件或目录已经存在",
   "malilib.error.invalid_directory": "无效的目录名称：'%s'",
   "malilib.error.invalid_block_blacklist_entry": "黑名单或白名单中的无效方块: '%s'",
   "malilib.error.invalid_item_blacklist_entry": "黑名单或白名单中无效的物品名称: '%s'",
+
   "malilib.gui.button.cancel": "取消",
   "malilib.gui.button.ok": "确定",
   "malilib.gui.button.reset": "重置",
   "malilib.gui.button.reset.caps": "重置",
+
   "malilib.gui.button.render_layers_gui.axis": "轴: %s",
   "malilib.gui.button.render_layers_gui.layers": "显示层: %s",
   "malilib.gui.button.render_layers_gui.set_here": "设置到玩家位置",
+
   "malilib.gui.button.hover.directory_widget.create_directory": "创建一个新目录",
   "malilib.gui.button.hover.directory_widget.root": "切换到根目录/基本目录",
   "malilib.gui.button.hover.directory_widget.up": "切换到父目录",
   "malilib.gui.button.hover.hold_shift_for_info": "§o按住Shift键可获得更多信息§r",
   "malilib.gui.button.hover.plus_minus_tip": "左键单击以增大\n右击以减小\nShift或Alt增大尺寸",
+
   "malilib.gui.label.block_snap.center": "中心",
   "malilib.gui.label.block_snap.corner": "角",
   "malilib.gui.label.block_snap.none": "无",
+
   "malilib.gui.label_colored.off": "§c关闭§r",
   "malilib.gui.label_colored.on": "§a开启§r",
+
   "malilib.gui.label.color_editor.current_color": "当前颜色:",
+
   "malilib.gui.label.keybind_settings.activate_on": "开启",
   "malilib.gui.label.keybind_settings.allow_empty_keybind": "允许绑定按键为空",
   "malilib.gui.label.keybind_settings.allow_extra_keys": "允许额外绑定按键",
@@ -38,16 +46,24 @@
   "malilib.gui.label.keybind_settings.order_sensitive": "需求顺序",
   "malilib.gui.label.keybind_settings.tips": "-左键设置 \n-右键重置为默认值",
   "malilib.gui.label.keybind_settings.title_advanced_keybind_settings": "高级键绑定设置",
+
   "malilib.gui.label.layer_mode.all": "显示所有",
   "malilib.gui.label.layer_mode.all_above": "以上所有层",
   "malilib.gui.label.layer_mode.all_below": "以下所有层",
   "malilib.gui.label.layer_mode.layer_range": "之间所有层",
   "malilib.gui.label.layer_mode.single_layer": "单层",
+
+  "malilib.label.message_output_type.none": "无",
+  "malilib.label.message_output_type.actionbar": "快捷栏上方",
+  "malilib.label.message_output_type.message": "聊天",
+
   "malilib.gui.label.no": "否",
   "malilib.gui.label.yes": "是",
+
   "malilib.gui.label.render_layers.layer": "层数",
   "malilib.gui.label.render_layers.layer_max": "最大层",
   "malilib.gui.label.render_layers.layer_min": "最小层",
+
   "malilib.gui.title.all_hotkeys": "所有注册的热键",
   "malilib.gui.title.color_editor": "颜色编辑",
   "malilib.gui.title.configs": "malilib 配置",
@@ -56,31 +72,40 @@
   "malilib.gui.title.generic": "通用",
   "malilib.gui.title.keybind_settings.advanced": "高级快捷键绑定设置 %s",
   "malilib.gui.title.string_list_edit": "编辑'%s'的字符串列表",
+
+  "malilib.hover.color_indicator.open_color_editor": "打开颜色编辑器",
   "malilib.label.active_mode.always": "总是",
   "malilib.label.active_mode.never": "决不",
   "malilib.label.active_mode.with_key": "需要按键",
+
   "malilib.label.key_action.both": "两者都",
   "malilib.label.key_action.press": "按下",
   "malilib.label.key_action.release": "释放",
+
   "malilib.label.key_context.any": "任何",
   "malilib.label.key_context.gui": "界面内",
   "malilib.label.key_context.ingame": "游戏内",
+
   "malilib.label.list_type.blacklist": "黑名单",
   "malilib.label.list_type.none": "无",
   "malilib.label.list_type.whitelist": "白名单",
+
   "malilib.label.alignment.top_left": "左上角",
   "malilib.label.alignment.top_right": "右上角",
   "malilib.label.alignment.bottom_left": "左下角",
   "malilib.label.alignment.bottom_right": "右下角",
   "malilib.label.alignment.center": "中间",
+
   "malilib.message.directory_created": "已创建'%s'目录",
   "malilib.message.toggled": "%s 已%s",
   "malilib.message.value.off": "关闭",
   "malilib.message.value.on": "打开",
+
   "malilib.message.formatting_code.error": "§c",
   "malilib.message.formatting_code.info": "§f",
   "malilib.message.formatting_code.success": "§a",
   "malilib.message.formatting_code.warning": "§6",
+
   "malilib.message.layer_range.range_max": "最大",
   "malilib.message.layer_range.range_min": "最小",
   "malilib.message.moved_layer_range": "整体移动 by §a%s§r on the §a%s§r axis",


### PR DESCRIPTION
<!--要勾选下面的复选框 可以将文本[ ]改为[x]-->

- [x] 我已**仔细**阅读注意事项 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已对 PR 作出 [标记](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#github-pr)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang
  - 如果是 1.16 及以上的翻译，应该是：projects/{版本}/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json
- [x] 我已阅读并同意许可协议：[知识共享 署名-非商业性使用-相同方式共享 4.0 国际许可协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)；
- [ ] 刷新 PR 的标签/状态，有需要再点击；
