### PR TITLE
gregtech错误通配符格式%,d修改为%d

### DIFF
--- a/projects/1.12.2/assets/gregtechce/gregtech/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/gregtechce/gregtech/lang/zh_cn.lang
@@ -40,15 +40,15 @@ gregtech.multiblock.large_turbine.description=大型涡轮是一种使用蒸汽�
 item.invalid.name=无效物品
 fluid.empty=空
 
-metaitem.generic.fluid_container.tooltip=%,d/%,dL %s
+metaitem.generic.fluid_container.tooltip=%d/%dL %s
 metaitem.generic.fluid_container.tooltip_empty=空
-metaitem.generic.electric_item.tooltip=%,d/%,d EU - 等级§e%s
+metaitem.generic.electric_item.tooltip=%d/%d EU - 等级§e%s
 metaitem.electric.discharge_mode.enabled=§e释能模式已启用
 metaitem.electric.discharge_mode.disabled=§e释能模式已禁用
 metaitem.electric.discharge_mode.tooltip=潜行右击以开关释能模式
 
 metaitem.dust.tooltip.purify=扔进盛有水的炼药锅进行清洗
-metaitem.int_circuit.configuration=配置：%,d
+metaitem.int_circuit.configuration=配置：%d
 metaitem.credit.copper.name=铜币
 metaitem.credit.copper.tooltip=0.125 币值
 metaitem.credit.cupronickel.name=白铜币
@@ -63,7 +63,7 @@ metaitem.credit.osmium.name=锇币
 metaitem.credit.osmium.tooltip=4096 币值
 metaitem.credit.naquadah.name=硅岩币
 metaitem.credit.naquadah.tooltip=32768 币值
-metaitem.credit.darmstadtium.name=[[钅达]]币
+metaitem.credit.darmstadtium.name=币
 metaitem.credit.darmstadtium.tooltip=262144 币值
 
 metaitem.coin.gold.ancient.name=上古金币
@@ -138,7 +138,7 @@ metaitem.shape.extruder.ring.tooltip=用来制作环的模头
 metaitem.shape.extruder.cell.name=模头（单元）
 metaitem.shape.extruder.cell.tooltip=用来制作单元的模头
 metaitem.shape.extruder.ingot.name=模头（锭）
-metaitem.shape.extruder.ingot.tooltip=用来……等会，用熔炉不好吗？
+metaitem.shape.extruder.ingot.tooltip=用来等会，用熔炉不好吗？
 metaitem.shape.extruder.wire.name=模头（导线）
 metaitem.shape.extruder.wire.tooltip=用来制作导线的模头
 metaitem.shape.extruder.casing.name=模头（外壳）
@@ -694,8 +694,8 @@ metaitem.behavior.mode_switch.current_mode=模式：%s
 metaitem.tool.tooltip.primary_material=主材料：%s（%s 级）
 metaitem.tool.tooltip.attack_damage=攻击伤害：%,.1f
 metaitem.tool.tooltip.mining_speed=挖掘速度：%,.1f
-metaitem.tool.tooltip.durability=耐久度：%,d/%,d
-metaitem.tool.tooltip.rotor.efficiency=转子效率：%,d%%
+metaitem.tool.tooltip.durability=耐久度：%d/%d
+metaitem.tool.tooltip.rotor.efficiency=转子效率：%d%%
 metaitem.tool.tooltip.hammer.extra_drop=有一定几率掉落双倍粉碎的矿石
 
 cover.filter.blacklist.disabled=白名单
@@ -761,7 +761,7 @@ cover.machine_controller.name=机器控制覆盖板设置
 cover.machine_controller.normal=普通
 cover.machine_controller.inverted=反相
 cover.machine_controller.inverted.description=§e普通§r - 该模式下的覆盖板需要比设定强度小的红石信号来触发/n§e反相§r - 该模式下的覆盖板需要比设定强度大的红石信号来触发
-cover.machine_controller.redstone=最小红石信号强度：%,d
+cover.machine_controller.redstone=最小红石信号强度：%d
 cover.machine_controller.mode.machine=控制机器
 cover.machine_controller.mode.cover_up=控制覆盖板（顶面）
 cover.machine_controller.mode.cover_down=控制覆盖板（底面）
@@ -977,7 +977,7 @@ material.manganese=锰
 material.mercury=汞
 material.molybdenum=钼
 material.neodymium=钕
-material.darmstadtium=[[钅达]]
+material.darmstadtium=
 material.nickel=镍
 material.niobium=铌
 material.nitrogen=氮
@@ -1639,7 +1639,7 @@ recipemap.plasma_generator.name=等离子发电机
 behaviour.hoe=可以耕作泥土
 behaviour.soft_hammer=用以开启与关闭机器
 behaviour.lighter.tooltip=可以点火
-behaviour.lighter.uses=剩余次数：%,d
+behaviour.lighter.uses=剩余次数：%d
 behavior.plunger.description=右击机器以清除 1000mB 输出槽中的流体。/n潜行右击机器以清除 1000mB 输入槽中的流体。/n输入槽流体清除功能仅限于 GTCE 机器！
 behavior.toggle_energy_consumer.tooltip=右击切换模式
 
@@ -1664,7 +1664,7 @@ gregtech.block.surface_rock.underground_materials=地下岩层质地：%s
 
 metaitem.scanner.name=扫描仪
 metaitem.scanner.tooltip=对准表层岩石长按右键以勘探地下岩层质地
-behavior.scanner.analyzing=分析中……
+behavior.scanner.analyzing=分析中
 behavior.scanner.analyzing_failed=分析失败！
 behavior.scanner.analyzing_complete=分析完成！
 behavior.scanner.not_enough_energy=分析失败：能量不足！
@@ -1680,10 +1680,10 @@ fluid.distilled_water=蒸馏水
 
 # Wire coil blocks
 tile.wire_coil.tooltip_ebf=用于§a电力高炉§7时：
-tile.wire_coil.tooltip_heat=基础炉温：§e%,d K
+tile.wire_coil.tooltip_heat=基础炉温：§e%d K
 tile.wire_coil.tooltip_smelter=在§a工业熔炉§7中使用时：
-tile.wire_coil.tooltip_level=等级：§e%,d
-tile.wire_coil.tooltip_discount=能量减损：§a%,dx
+tile.wire_coil.tooltip_level=等级：§e%d
+tile.wire_coil.tooltip_discount=能量减损：§a%dx
 
 tile.wire_coil.cupronickel.name=白铜线圈方块
 tile.wire_coil.kanthal.name=坎塔尔合金线圈方块
@@ -1791,7 +1791,7 @@ gregtech.machine.workbench.tab.workbench=合成界面
 gregtech.machine.workbench.tab.item_list=存储空间
 gregtech.machine.workbench.storage_note_1=（相邻的物品容器中
 gregtech.machine.workbench.storage_note_2=可参与合成的物品）
-gregtech.item_list.item_stored=§7储量：%,d
+gregtech.item_list.item_stored=§7储量：%d
 
 gregtech.machine.workbench.tab.crafting=合成
 gregtech.machine.workbench.tab.container=存储
@@ -1862,7 +1862,7 @@ tile.concrete.dark_bricks.mossy.name=苔藓深色混凝土砖
 tile.concrete.dark_bricks.chiseled.name=錾制深色混凝土砖
 
 # Steam machines
-gregtech.machine.steam_boiler.tooltip_produces=产出蒸汽（%,d mB / %,d 刻）
+gregtech.machine.steam_boiler.tooltip_produces=产出蒸汽（%d mB / %d 刻）
 
 gregtech.machine.steam_boiler_coal_bronze.name=小型燃煤锅炉
 gregtech.machine.steam_boiler_coal_bronze.tooltip=获取蒸汽能源的早期手段
@@ -1924,7 +1924,7 @@ gregtech.machine.block_breaker.mv.name=进阶方块破坏器
 gregtech.machine.block_breaker.hv.name=进阶方块破坏器 II
 gregtech.machine.block_breaker.ev.name=进阶方块破坏器 III
 gregtech.machine.block_breaker.tooltip=挖掘前方方块并收集掉落物
-gregtech.machine.block_breaker.consumption=每次挖掘消耗§e%,d EU§7
+gregtech.machine.block_breaker.consumption=每次挖掘消耗§e%d EU§7
 gregtech.machine.block_breaker.speed_bonus=速度加成：§e%d%%
 
 gregtech.machine.electric_furnace.lv.name=基础电炉
@@ -2230,9 +2230,9 @@ gregtech.machine.battery_buffer.max.16.name=上限压电池箱
 # Transformers
 gregtech.machine.transformer.tooltip_tool_usage=用软锤右击以反转（默认降压）
 gregtech.machine.transformer.tooltip_transform_down=降压：
-gregtech.machine.transformer.message_transform_down=降压，输入：%,d V %,d A，输出：%,d V %,d A
+gregtech.machine.transformer.message_transform_down=降压，输入：%d V %d A，输出：%d V %d A
 gregtech.machine.transformer.tooltip_transform_up=升压：
-gregtech.machine.transformer.message_transform_up=升压，输入：%,d V %,d A，输出：%,d V %,d A
+gregtech.machine.transformer.message_transform_up=升压，输入：%d V %d A，输出：%d V %d A
 
 gregtech.machine.transformer.lv.name=低压变压器
 gregtech.machine.transformer.mv.name=中压变压器
@@ -2257,8 +2257,8 @@ gregtech.machine.charger.uv.name=极限压充电箱
 gregtech.machine.charger.max.name=上限压充电箱
 
 # Pumps
-gregtech.machine.pump.tooltip_range=工作范围：%,dx%,d
-gregtech.machine.pump.tooltip_speed=每 %,d 刻抽取一次
+gregtech.machine.pump.tooltip_range=工作范围：%dx%d
+gregtech.machine.pump.tooltip_speed=每 %d 刻抽取一次
 
 gregtech.machine.pump.lv.name=基础泵
 gregtech.machine.pump.mv.name=进阶泵
@@ -2270,15 +2270,15 @@ gregtech.machine.item_collector.mv.name=进阶物品收集器
 gregtech.machine.item_collector.hv.name=进阶物品收集器 II
 gregtech.machine.item_collector.ev.name=进阶物品收集器 III
 
-gregtech.machine.item_collector.collect_range=收集范围：%,dx%,d
+gregtech.machine.item_collector.collect_range=收集范围：%dx%d
 gregtech.machine.item_collector.gui.collect_range=收集 %s 格范围内的掉落物
 
 #Quantum chests
 gregtech.machine.quantum_chest.tooltip=比 JABBA 好。
-gregtech.machine.quantum_chest.capacity=物品容量：%,d 个
+gregtech.machine.quantum_chest.capacity=物品容量：%d 个
 gregtech.machine.quantum_chest.items_stored=物品储量：
 gregtech.machine.quantum_chest.tooltip.item=物品种类：§b%s
-gregtech.machine.quantum_chest.tooltip.count=物品储量：§e%,d
+gregtech.machine.quantum_chest.tooltip.count=物品储量：§e%d
 
 gregtech.machine.quantum_chest.mv.name=基础量子箱
 gregtech.machine.quantum_chest.hv.name=进阶量子箱
@@ -2287,9 +2287,9 @@ gregtech.machine.quantum_chest.iv.name=黑洞量子箱 III
 
 #Quantum tanks
 gregtech.machine.quantum_tank.tooltip=储存你全部流体的简洁渠道。
-gregtech.machine.quantum_tank.capacity=流体容量：%,d mB
+gregtech.machine.quantum_tank.capacity=流体容量：%d mB
 gregtech.machine.quantum_tank.tooltip.name=流体种类：§b%s
-gregtech.machine.quantum_tank.tooltip.count=流体储量：§e%,d mB
+gregtech.machine.quantum_tank.tooltip.count=流体储量：§e%d mB
 
 gregtech.machine.quantum_tank.mv.name=基础量子缸
 gregtech.machine.quantum_tank.hv.name=进阶量子缸
@@ -2302,7 +2302,7 @@ gregtech.machine.air_collector.mv.name=进阶空气收集器
 gregtech.machine.air_collector.hv.name=进阶空气收集器 II
 gregtech.machine.air_collector.ev.name=大气收集器 III
 gregtech.machine.air_collector.tooltip=从临近方块中收集空气
-gregtech.machine.air_collector.collection_speed=效率：%,d mB / %,d 刻
+gregtech.machine.air_collector.collection_speed=效率：%d mB / %d 刻
 gregtech.machine.air_collector.jei_description=空气收集器能以较小的EU能耗来从临近空间中收集空气
 
 #Tesla Coil
@@ -2316,7 +2316,7 @@ gregtech.machine.fisher.hv.name=进阶捕鱼机 II
 gregtech.machine.fisher.ev.name=进阶捕鱼机 III
 gregtech.machine.fisher.tooltip=消耗线捕鱼。每次运行消耗一根线。
 gregtech.machine.fisher.speed=每%d刻获得一条鱼（或者其它什么东西）
-gregtech.machine.fisher.requirement=需要在正下方倾倒边长为 %,d 格的静止水。
+gregtech.machine.fisher.requirement=需要在正下方倾倒边长为 %d 格的静止水。
 
 # General machinery
 gregtech.machine.basic.input_from_output_side.allow=允许输出端输入
@@ -2759,7 +2759,7 @@ behaviour.paintspray.brown.tooltip=可以将物体染成棕色
 behaviour.paintspray.green.tooltip=可以将物体染成绿色
 behaviour.paintspray.red.tooltip=可以将物体染成红色
 behaviour.paintspray.black.tooltip=可以将物体染成黑色
-behaviour.paintspray.uses=剩余次数：%,d次
+behaviour.paintspray.uses=剩余次数：%d次
 behaviour.prospecting=适用于探矿
 
 # Multiblock machine controllers
@@ -2878,34 +2878,34 @@ gregtech.machine.rotor_holder.zpm.name=转子支架（ZPM）
 gregtech.machine.rotor_holder.uv.name=转子支架（UV）
 gregtech.machine.rotor_holder.max.name=转子支架（MAX）
 
-gregtech.machine.fluid_tank.max_multiblock=多方块结构最大尺寸：%,dx%,dx%,d
+gregtech.machine.fluid_tank.max_multiblock=多方块结构最大尺寸：%dx%dx%d
 gregtech.machine.fluid_tank.fluid=含有 %s mB %s
 
 gregtech.machine.item_controller.tooltip.redstone=需要输入红石信号才能工作
-gregtech.machine.item_controller.tooltip.consumption=工作时稳定消耗%,d EU / t
+gregtech.machine.item_controller.tooltip.consumption=工作时稳定消耗%d EU / t
 
 # Universal tooltips
-gregtech.universal.tooltip.voltage_in=输入电压：§a%,d§7（§a%s§7）
-gregtech.universal.tooltip.voltage_out=输出电压：§a%,d§7（§a%s§7）
-gregtech.universal.tooltip.energy_storage_capacity=电能缓存：§9%,d
-gregtech.universal.tooltip.amperage_in=输入电流：§e%,d
-gregtech.universal.tooltip.amperage_in_till=最大输入电流：§e%,d
-gregtech.universal.tooltip.amperage_out=输出电流：§e%,d
-gregtech.universal.tooltip.amperage_out_till=最大输出电流: §e%,d
-gregtech.universal.tooltip.item_storage_capacity=物品储量：%,d
-gregtech.universal.tooltip.fluid_storage_capacity=流体储量：%,d mB
-gregtech.universal.tooltip.max_voltage_in=最大输入电压: §a%,d§7（§a%s§7）
+gregtech.universal.tooltip.voltage_in=输入电压：§a%d§7（§a%s§7）
+gregtech.universal.tooltip.voltage_out=输出电压：§a%d§7（§a%s§7）
+gregtech.universal.tooltip.energy_storage_capacity=电能缓存：§9%d
+gregtech.universal.tooltip.amperage_in=输入电流：§e%d
+gregtech.universal.tooltip.amperage_in_till=最大输入电流：§e%d
+gregtech.universal.tooltip.amperage_out=输出电流：§e%d
+gregtech.universal.tooltip.amperage_out_till=最大输出电流: §e%d
+gregtech.universal.tooltip.item_storage_capacity=物品储量：%d
+gregtech.universal.tooltip.fluid_storage_capacity=流体储量：%d mB
+gregtech.universal.tooltip.max_voltage_in=最大输入电压: §a%d§7（§a%s§7）
 
-gregtech.recipe.total=电量总计：%,d EU
-gregtech.recipe.eu=消耗功率：%,d EU/t (%s)
-gregtech.recipe.eu_inverted=产能：%,d EU/t
+gregtech.recipe.total=电量总计：%d EU
+gregtech.recipe.eu=消耗功率：%d EU/t (%s)
+gregtech.recipe.eu_inverted=产能：%d EU/t
 gregtech.recipe.duration=耗时：%,.1f 秒
-gregtech.recipe.amperage=电流：%,d
+gregtech.recipe.amperage=电流：%d
 gregtech.recipe.not_consumed=不在加工时消耗
 gregtech.recipe.chance=出产概率：%s%% +%s%%/电压等级
-gregtech.recipe.blast_furnace_temperature=温度：%,d K（%s）
+gregtech.recipe.blast_furnace_temperature=温度：%d K（%s）
 gregtech.recipe.explosive=Explosive: %s
-gregtech.recipe.eu_to_start=启动耗电：%,d EU
+gregtech.recipe.eu_to_start=启动耗电：%d EU
 
 gregtech.fluid.click_to_fill=§7手持空的流体容器点击流体槽以取走流体。
 gregtech.fluid.click_to_fill.shift=§7（Shift+单击将装满所有手持容器）
@@ -2915,8 +2915,8 @@ gregtech.fluid.click_to_empty.shift=§7（Shift+单击将倒出手持容器内�
 
 gregtech.fluid.plasma=%s等离子体
 gregtech.fluid.empty=空
-gregtech.fluid.amount=§7%,d/%,d
-gregtech.fluid.temperature=§7温度：%,dK
+gregtech.fluid.amount=§7%d/%d
+gregtech.fluid.temperature=§7温度：%dK
 gregtech.fluid.state_gas=§7状态：气态
 gregtech.fluid.state_liquid=§7状态：液态
 gregtech.gui.fuel_amount=燃料总量：


### PR DESCRIPTION
<!--
要勾选下面的复选框 可以将文本[ ]改为[x]，注意别误删前后的空格。
务必认真阅读并完成此检查单。如有其他需说明的事项请写在检查单之前。
-->

- [x] 我已**仔细**阅读贡献指南 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已确认标题符合`{模组英文全名} {简述}`的格式，如`Ender IO 翻译新增/更新/修正/删除`；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang
  - 如果是 1.16 及以上的翻译，应该是：projects/{版本}/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json
- [x] 我已阅读并同意按 [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh) 协议发布我的作品；
- [x] 刷新 PR 的标签/状态，有需要再点击；

![F `F2C$))S@}1C@935 64 9](https://user-images.githubusercontent.com/5901229/178653405-ace907ed-ea89-44ee-a7be-c6b5cb6ae1e2.png)
玩包的时候碰到的%,d