### PR TITLE
修复了格雷社区版的配方乱码（应该无%s）

### DIFF
--- a/projects/1.12.2/assets/gregtechce/gregtech/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/gregtechce/gregtech/lang/zh_cn.lang
@@ -2897,13 +2897,13 @@ gregtech.universal.tooltip.fluid_storage_capacity=流体储量：%,d mB
 gregtech.universal.tooltip.max_voltage_in=最大输入电压: §a%,d§7（§a%s§7）
 
 gregtech.recipe.total=电量总计：%,d EU
-gregtech.recipe.eu=消耗功率：%,d EU/t (%s)
+gregtech.recipe.eu=消耗功率：%,d EU/t
 gregtech.recipe.eu_inverted=产能：%,d EU/t
 gregtech.recipe.duration=耗时：%,.1f 秒
 gregtech.recipe.amperage=电流：%,d
 gregtech.recipe.not_consumed=不在加工时消耗
 gregtech.recipe.chance=出产概率：%s%% +%s%%/电压等级
-gregtech.recipe.blast_furnace_temperature=温度：%,d K（%s）
+gregtech.recipe.blast_furnace_temperature=温度：%,d K
 gregtech.recipe.explosive=Explosive: %s
 gregtech.recipe.eu_to_start=启动耗电：%,d EU
 


### PR DESCRIPTION
<!--
要勾选下面的复选框 可以将文本[ ]改为[x]，注意别误删前后的空格。
务必认真阅读并完成此检查单。如有其他需说明的事项请写在检查单之前。
-->

- [x] 我已**仔细**阅读贡献指南 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已确认标题符合`{模组英文全名} {简述}`的格式，如`Ender IO 翻译新增/更新/修正/删除`；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已确认提交文件的**路径**和**名称**均**正确**（[例子](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md#提交文件路径的例子)）；
  - 如果是 1.12 翻译，应该是：projects/1.12.2/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.lang
  - 如果是 1.16 及以上的翻译，应该是：projects/{版本}/assets/{CurseForge 项目名称}/{ModID}/lang/zh_cn.json
- [x] 我已阅读并同意按 [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh) 协议发布我的作品；
- [x] 刷新 PR 的标签/状态，有需要再点击；
