### PR TITLE
Packer 再度更新

### DIFF
--- a/Packer-Index-Doc.md
+++ b/Packer-Index-Doc.md
@@ -1,7 +1,9 @@
 # 打包机制-自定义文件检索策略
 
 本仓库的打包器支持对不同模组使用不同的**检索策略**。
-注意：检索策略仅对**文本文件**有效；**非文本文件**无法通过默认的检索途径，需要在`config/packer.json`中设置绕过检索。详见[此处](./CONTRIBUTING.md#configpackerjson)
+## 注意事项
+- 检索策略仅对**文本文件**有效；**非文本文件**无法通过默认的检索途径，需要在`config/packer.json`中设置绕过检索。详见[此处](./CONTRIBUTING.md#configpackerjson)。
+- 检索策略目前不支持递归调用；所有对于其余位置的引用都不会读取引用位置的`packer-policy.json`。
 
 ## 策略配置
 
@@ -16,8 +18,10 @@ packer-policy.json
     - `noaction` 默认选项。不进行特殊处理，直接按照此处的文件结构打包。如果没有对文件同步或版本对照的特殊要求，使用该类型。如：[示例文件](./projects/1.19/assets/0-example-nop/nop/packer-policy.json)
     - `plainclone` 直接引用另一位置的文件结构。如果需要文本完全同步，使用该类型。如：[示例文件](./projects/1.19/assets/0-example-simple-clone/clone/packer-policy.json)
       - `source` string -> 复制的源地址。需要从本仓库的根目录开始计算，使用`./`前缀。
-    - `clonemissing` 使用此处的文件结构，但在检索完文件后，根据另一位置的文件结构补充文本。对于出现冲突的条目，若为`lang/`下的内容，将会按照`key`合并，冲突项采用此处的文本；若为其他位置的文件，直接采用此处的文件。如：[示例文件](./projects/1.19/assets/0-example-mixed-clone/mixed-clone/packer-policy.json)
+    - `clonemissing` 使用此处的文件结构，但在检索完文件后，根据另一位置的文件结构**补充**文本。对于出现冲突的条目，若为`lang/`下的内容，将会按照`key`合并，冲突项采用此处的文本；若为其他位置的文件，直接采用此处的文件。如：[示例文件](./projects/1.19/assets/0-example-mixed-clone/mixed-clone/packer-policy.json)
       - `source` string -> 补充文件的源地址。需要从本仓库的根目录开始计算，使用`./`前缀。
+    - `backport` 使用此处的文件结构，但在此基础上，从另一位置的文件结构**更新**已有的文本。对于`lang/`下的内容，仅会对已有的`key`更新内容，原本不存在的`key`不会新增；对于其他位置的文件，仅会对已有的文件进行替换，原本不存在的文件不会新增。例如，如果需要从高版本将文件同步至低版本，使用该类型。如：[示例文件](./projects/1.19/assets/0-example-port/port/packer-policy.json)
+      - `source` string -> 更新文件的源地址。需要从本仓库的根目录开始计算，使用`./`前缀。
     - `patch` 引用另一位置的文件结构，但在其中的部分文件上额外应用自定义的修改。修改使用[Google Diff-Match-Patch算法](https://github.com/google/diff-match-patch)生成；尽管原则上可以放在任意位置、采用任意后缀名，建议将修改文件放在被修改文件相应的位置，采用`.patch`后缀，以保持统一性。如：[示例文件](./projects/1.19/assets/0-example-patch/patch/packer-policy.json)
       - `source` string -> 复制的源地址。需要从本仓库的根目录开始计算，使用`./`前缀。
       - `patches` object -> 修改文件，以及对应的修改目标。

--- a/config/packer.json
+++ b/config/packer.json
@@ -1,8 +1,8 @@
 [
     {
         "targetVersion": "1.12.2",
-        "unTargetLang": [
-            "en_us"
+        "targetLanguage": [
+            "zh_cn"
         ],
         "additionalContent": [
             "LICENSE",
@@ -11,7 +11,7 @@
             "README.md"
         ],
         "modNameBlackList": [
-        "gregtechce"
+            "gregtechce"
         ],
         "domainBlackList": [],
         "noProcessNamespace": [
@@ -21,8 +21,8 @@
     },
     {
         "targetVersion": "1.16",
-        "unTargetLang": [
-            "en_us"
+        "targetLanguage": [
+            "zh_cn"
         ],
         "additionalContent": [
             "LICENSE",
@@ -39,8 +39,8 @@
     },
     {
         "targetVersion": "1.16-fabric",
-        "unTargetLang": [
-            "en_us"
+        "targetLanguage": [
+            "zh_cn"
         ],
         "additionalContent": [
             "LICENSE",
@@ -57,8 +57,8 @@
     },
     {
         "targetVersion": "1.18",
-        "unTargetLang": [
-            "en_us"
+        "targetLanguage": [
+            "zh_cn"
         ],
         "additionalContent": [
             "LICENSE",
@@ -75,8 +75,8 @@
     },
     {
         "targetVersion": "1.18-fabric",
-        "unTargetLang": [
-            "en_us"
+        "targetLanguage": [
+            "zh_cn"
         ],
         "additionalContent": [
             "LICENSE",
@@ -93,8 +93,8 @@
     },
     {
         "targetVersion": "1.19",
-        "unTargetLang": [
-            "en_us"
+        "targetLanguage": [
+            "zh_cn"
         ],
         "additionalContent": [
             "LICENSE",
@@ -106,7 +106,8 @@
             "0-example-nop",
             "0-example-patch",
             "0-example-simple-clone",
-            "0-example-mixed-clone"
+            "0-example-mixed-clone",
+            "0-example-port"
         ],
         "domainBlackList": [],
         "noProcessNamespace": [

--- a/projects/1.19/assets/0-example-port/port/lang/zh_cn.json
+++ b/projects/1.19/assets/0-example-port/port/lang/zh_cn.json
@@ -1,0 +1,4 @@
+{
+    "key1": "value1",
+    "key4": "value4"
+}

--- a/projects/1.19/assets/0-example-port/port/packer-policy.json
+++ b/projects/1.19/assets/0-example-port/port/packer-policy.json
@@ -1,0 +1,4 @@
+{
+    "type": "backport",
+    "source": "./projects/1.19/assets/0-example-mixed-clone/mixed-clone"
+}

--- a/src/Packer/Extensions/ContentExtension.cs
+++ b/src/Packer/Extensions/ContentExtension.cs
@@ -88,9 +88,9 @@ namespace Packer.Extensions
         /// <param name="location">文件所在的位置</param>
         /// <param name="config">所使用的配置</param>
         /// <returns></returns>
-        public static bool IsSkippedLang(this string location, Config config)
+        public static bool IsTargetLang(this string location, Config config)
         {
-            foreach (var lang in config.SkippedLanguages)
+            foreach (var lang in config.TargetLanguages)
             {
                 if (location.Contains(lang, StringComparison.OrdinalIgnoreCase)) return true;
             }

--- a/src/Packer/Extensions/DirectoryExtension.cs
+++ b/src/Packer/Extensions/DirectoryExtension.cs
@@ -113,7 +113,7 @@ namespace Packer.Extensions
                     var prefixLength = assetDirectory.FullName.Length;
                     var relativePath = file.FullName[(prefixLength + 1)..]; // 在asset-domain下的位置，用反斜杠分割
 
-                    // 跳过非中尉文件
+                    // 跳过非中文文件
                     if (!relativePath.IsTargetLang(config))
                     {
                         return null;

--- a/src/Packer/Extensions/DirectoryExtension.cs
+++ b/src/Packer/Extensions/DirectoryExtension.cs
@@ -42,7 +42,8 @@ namespace Packer.Extensions
                 { PackerStrategyType.NoAction, FromImmediateDirectory },
                 { PackerStrategyType.PlainClone, FromIndirectDirectory },
                 { PackerStrategyType.CloneMissing, FromMixedDirectory },
-                { PackerStrategyType.Patch, FromPatches}
+                { PackerStrategyType.BackPort, FromBackPort },
+                { PackerStrategyType.Patch, FromPatches }
             };
             return functionTable[policy.Type](assetPath, config, ref bypassed, policy.Parameters);
         }
@@ -67,6 +68,13 @@ namespace Packer.Extensions
             => Utils.MergeFiles(FromImmediateDirectory(assetDirectory, config, ref unprocessed, parameters),
                                 FromIndirectDirectory(assetDirectory, config, ref unprocessed, parameters));
 
+        static IEnumerable<TranslatedFile> FromBackPort(DirectoryInfo assetDirectory,
+                                                              Config config,
+                                                              ref Dictionary<string, string> unprocessed,
+                                                              Dictionary<string, JsonElement> parameters)
+            => Utils.PortFiles(FromImmediateDirectory(assetDirectory, config, ref unprocessed, parameters),
+                                FromIndirectDirectory(assetDirectory, config, ref unprocessed, parameters));
+
         static IEnumerable<TranslatedFile> FromIndirectDirectory(DirectoryInfo assetDirectory,
                                                                  Config config,
                                                                  ref Dictionary<string, string> unprocessed,
@@ -83,7 +91,7 @@ namespace Packer.Extensions
             var patchList = JsonSerializer.Deserialize<Dictionary<string, string>>(parameters["patches"]);
             foreach (var patch in patchList)
             {
-                Log.Information("{0}", reference.Keys);
+                //Log.Information("{0}", reference.Keys);
                 Log.Information("对文件 {0} 应用 {1} 处的 patch。", patch.Key, patch.Value);
                 var target = reference[patch.Key];
                 var patchText = string.Join('\n', File.ReadAllLines(patch.Value)); // 不要问我为什么D-M-P默认换行是LF
@@ -103,10 +111,10 @@ namespace Packer.Extensions
                                        .Select(file =>
                 {   // 这里开始真正的检索。被跳过的文本用 null 代替
                     var prefixLength = assetDirectory.FullName.Length;
-                    var relativePath = file.FullName[(prefixLength + 1)..]; // 在asset-domain下的位置
+                    var relativePath = file.FullName[(prefixLength + 1)..]; // 在asset-domain下的位置，用反斜杠分割
 
-                    // 跳过英文文件
-                    if (relativePath.IsSkippedLang(config))
+                    // 跳过非中尉文件
+                    if (!relativePath.IsTargetLang(config))
                     {
                         return null;
                     }

--- a/src/Packer/Models/Config.cs
+++ b/src/Packer/Models/Config.cs
@@ -16,12 +16,11 @@ namespace Packer
         public string Version { get; set; }
 
         /// <summary>
-        /// 打包的<c>非</c>目标语言<br></br>
-        /// 为了尽量减少功能变动（避免以后秃头），尽量保持原方式<br></br>
+        /// 打包的目标语言<br></br>
         /// 为<c>1.20</c>准备，因为据说语言文件名要改
         /// </summary>
-        [JsonPropertyName("unTargetLang")]
-        public string[] SkippedLanguages { get; set; }
+        [JsonPropertyName("targetLanguage")]
+        public string[] TargetLanguages { get; set; }
 
         /// <summary>
         /// 打包过程的基础文件（如在assets/以外的文件，或不宜通过打包流程的）

--- a/src/Packer/Models/PackerStrategy.cs
+++ b/src/Packer/Models/PackerStrategy.cs
@@ -28,6 +28,12 @@ namespace Packer.Models
         /// </summary>
         CloneMissing,
         /// <summary>
+        /// 使用此处的文件结构，仅对此处存在的条目从源地址更新<br></br>
+        /// 附加参数：<br></br>
+        /// "source": string 复制源地址
+        /// </summary>
+        BackPort,
+        /// <summary>
         /// 从某处复制文件，然后应用由Google Diff-Match-Patch算法生成的修改项<br></br>
         /// 附加参数：<br></br>
         /// "source": string 复制源地址<br></br>


### PR DESCRIPTION
根据@mamaruo 的意见修改了一下Packer。

- config调整：现在指定的是**目标语言**而非**非目标语言**了。
- packer-policy新增`backport`类型，可以使用于高版本向低版本适配

预期效果：（假定忽略blacklist）
assets/port内仅有lang/zh_cn.json：
```json
{
    "key1": "new value 1",
    "key4": "value4"
}
```

- [ ] 刷新 PR 的标签/状态，有需要再点击；
