### PR TITLE
新增action：自动执行7+7措施

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,4 +21,5 @@ jobs:
           days-before-pr-close: 7
           any-of-pr-labels: "needs author action,changes required"
           stale-pr-label: "stale"
+          start-date: 2023-02-11
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,6 +20,6 @@ jobs:
           days-before-pr-stale: 7
           days-before-pr-close: 7
           any-of-pr-labels: "needs author action,changes required"
-          stale-pr-label: "stale"
+          stale-pr-label: "ready to reject"
           start-date: 2023-02-11
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Close inactive PRs
+on:
+  schedule:
+    # 每天凌晨5点
+    - cron: "0 21 * * *"
+  workflow_dispatch:
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-message: "提醒：审核者需要您的回复，7+7已进入第二阶段，该PR即将关闭。"
+          close-pr-message: "因审核者请求您更新该PR，且回复时间超过规定期限，该PR现暂时关闭。如您需再次提交可重新打开该PR，感谢您的贡献:heart:。"
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+          any-of-pr-labels: "needs author action,changes required"
+          stale-pr-label: "stale"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
要勾选下面的复选框 可以将文本[ ]改为[x]，注意别误删前后的空格。
务必认真阅读并完成此检查单。如有其他需说明的事项请写在检查单之前。
若检查单出现不会使用的情况，请查看Issues列表的 #2539 “检查单”使用说明 & 错误“检查单”使用情况报告
-->

- [x] 我已**仔细**阅读贡献指南 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已阅读并同意按 [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh) 协议发布我的作品；
- [x] Make [life](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/issues/2658) easier
## 功能
- 定时每天凌晨5点检查带有`needs author action`或`change required`标签的PR，自动实行7+7
- 从2023-02-12 05:00起创建的PR开始生效
- 测试效果见ricky-fight/Minecraft-Mod-Language-Package#5、ricky-fight/Minecraft-Mod-Language-Package#6
