### PR TITLE
 ChinjufuMod + JapaneseBlock 补充缺失的空格

### DIFF
--- a/projects/1.12.2/assets/chinjufumod/chinjufumod/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/chinjufumod/chinjufumod/lang/zh_cn.lang
@@ -115,33 +115,33 @@ advancements.cm_story.fishing.youshoku.description=获得养殖网
 config.bauxiteore.enabledGenerator=生成铝土矿石
 config.bauxiteore.enabledGenerator.tooltip=，生成铝土矿石
 config.bauxiteore.chance=铝土矿石的生成频率
-config.bauxiteore.chance.tooltip=红石矿石为25，金矿石为8
+config.bauxiteore.chance.tooltip=红石矿石为 25，金矿石为 8
 
 config.cherrybiome.register=生成樱生物群系
 config.cherrybiome.register.tooltip=生成樱生物群系
 config.cherrybiome.chance=樱生物群系的生成频率
-config.cherrybiome.chance.tooltip=常见为19，稀有为1
+config.cherrybiome.chance.tooltip=常见为 19，稀有为 1
 config.cherrytree.chance=樱花树的生成频率
-config.cherrytree.chance.tooltip=常见为19，稀有为1
+config.cherrytree.chance.tooltip=常见为 19，稀有为 1
 
 config.acerbiome.register=生成枫生物群系
 config.acerbiome.register.tooltip=生成枫生物群系
 config.acerbiome.chance=枫生物群系的生成频率
-config.acerbiome.chance.tooltip=常见为19，稀有为1
+config.acerbiome.chance.tooltip=常见为 19，稀有为 1
 config.acertree.chance=枫树的生成频率
-config.acertree.chance.tooltip=常见为19，稀有为1
+config.acertree.chance.tooltip=常见为 19，稀有为 1
 
 config.ginkgobiome.register=生成银杏生物群系
 config.ginkgobiome.register.tooltip=生成银杏生物群系
 config.ginkgobiome.chance=银杏生物群系的生成频率
-config.ginkgobiome.chance.tooltip=常见为19，稀有为1
+config.ginkgobiome.chance.tooltip=常见为 19，稀有为 1
 config.ginkgotree.chance=银杏树的生成频率
-config.ginkgotree.chance.tooltip=常见为19，稀有为1
+config.ginkgotree.chance.tooltip=常见为 19，稀有为 1
 
 config.blastblockbreak.enabled=弹药爆炸时破坏方块
 config.blastblockbreak.enabled.tooltip=弹药爆炸会破坏方块
 
-config.antiShadow=为推拉门等方块赋予具有1光照等级以消除阴影
+config.antiShadow=为推拉门等方块赋予具有 1 光照等级以消除阴影
 
 config.usemakimono=启用卷轴方块
 config.usemakimono.tooltip=使用台案撰写附魔书时生成卷轴方块而非书方块
@@ -345,7 +345,7 @@ item.block_lowdesk_sakura.name=樱花木矮桌
 
 item.block_lettertray_c.name=羽毛笔套装
 item.block_fudetray_c.name=台案
-tips.block_lettertray.name=使用书和10点经验撰写一本随机附魔书
+tips.block_lettertray.name=使用书和 10 点经验撰写一本随机附魔书
 
 #Funiture
 item.block_admiralchair.name=提督椅
@@ -570,11 +570,11 @@ tile.block_ctruss_yellow.name=黄色桁架
 
 #Seasons
 item.block_kagamimochi.name=镜饼
-tips.block_kagamimochi.name=新年期间（12月28日-1月11日）供奉给谷物之神（年神），以祈求五谷丰收
+tips.block_kagamimochi.name=新年期间（12 月 28 日-1 月 11 日）供奉给谷物之神（年神），以祈求五谷丰收
 tile.block_shimenawa.name=注连绳
-tips.block_shimenawa.name=新年期间（12月13日-1月15日）迎接年神的新年饰品，象征家里已经清扫干净
+tips.block_shimenawa.name=新年期间（12 月 13 日-1 月 15 日）迎接年神的新年饰品，象征家里已经清扫干净
 item.block_kadomatsu.name=门松
-tips.block_kadomatsu.name=新年期间（12月13日-1月15日）迎接年神的新年饰品，以祈求长寿
+tips.block_kadomatsu.name=新年期间（12 月 13 日-1 月 15 日）迎接年神的新年饰品，以祈求长寿
 
 item.block_yunomi.name=茶碗
 tips.block_yunomi.name=用于饮用绿茶等饮品
@@ -604,7 +604,7 @@ tips.block_kotatsu.name=将桌子与被子组合起来的加热装置
 tile.block_hinadan.name=阶梯底座
 tips.block_hinadan.name=雏祭时摆放装饰的底座
 tile.block_hinakazari.name=雏祭摆饰
-tips.block_hinakazari.name=雏祭（3月3日）即女儿节上摆设，祈求女孩健康成长
+tips.block_hinakazari.name=雏祭（3 月 3 日）即女儿节上摆设，祈求女孩健康成长
 
 #Wallpane
 tile.block_pillar_aca_c.name=金合欢木柱
@@ -790,9 +790,9 @@ tile.block_wp_namako_b_red.name=甲型红色海鼠壁隔板
 tile.block_wp_namako_b_white.name=甲型白色海鼠壁隔板
 tile.block_wp_namako_b_yellow.name=甲型黄色海鼠壁隔板
 
-tips.wp_stage2.name=潜行右击以更换纹路，共2种
-tips.wp_stage3.name=潜行右击以更换纹路，共3种
-tips.wp_stage4.name=潜行右击以更换纹路，共4种
+tips.wp_stage2.name=潜行右击以更换纹路，共 2 种
+tips.wp_stage3.name=潜行右击以更换纹路，共 3 种
+tips.wp_stage4.name=潜行右击以更换纹路，共 4 种
 
 #Fusuma
 tile.block_shoujih.name=障子窗
@@ -1215,7 +1215,7 @@ tile.block_kit_board.name=砧板
 tips.block_kit_board.name=可作工作台使用
 
 item.block_kit_sink.name=水槽
-tips.block_kit_sink.name=如果下方2格内有水源，右击水龙头以出水
+tips.block_kit_sink.name=如果下方 2 格内有水源，右击水龙头以出水
 
 tile.block_kit_stove.name=灶台
 tips.block_kit_stove.name=潜行右击以开火，右击以关火
@@ -1483,7 +1483,7 @@ tips.block_rice.name=可种植于水田或耕地，在水田里多生长一个�
 item.item_seeds_hakusai.name=白菜种子
 
 item.block_seedsbox.name=种子袋
-tips.block_seedsbox.name=放置后破坏可以获得随机种子（共11种）
+tips.block_seedsbox.name=放置后破坏可以获得随机种子（共 11 种）
 
 item.block_wood_chanoki_nae.name=茶树种子
 tips.block_wood_chanoki_nae.name=种植于亮度充足的泥土上即可生长
@@ -2048,26 +2048,26 @@ item.block_food_pastatoma_1.name=番茄酱意大利面
 item.block_taru_hakusai_f.name=腌菜桶（发酵初期）
 tips.block_taru_hakusai_f.name=腌制白菜的桶，当发酵出水后破坏方块收集
 item.block_taru_hakusai_f2.name=腌菜桶（发酵中后期）
-tips.block_taru_hakusai_f2.name=腌制白菜的桶，用碟子收集（可盛4次）
+tips.block_taru_hakusai_f2.name=腌制白菜的桶，用碟子收集（可盛 4 次）
 item.item_food_hakusai2.name=初熟腌白菜
 item.block_food_hsd_1.name=成熟腌白菜
 
 item.block_taru_komezu_f.name=米醋桶
-tips.block_taru_komezu.name=酿造米醋的桶，用玻璃瓶收集（可盛4次）
+tips.block_taru_komezu.name=酿造米醋的桶，用玻璃瓶收集（可盛 4 次）
 item.block_komezu_bot.name=米醋
 item.block_komezu_bot_2.name=米醋
 
 item.block_taru_shouyu_f.name=酱油桶
-tips.block_taru_shouyu.name=酿造酱油的桶，用玻璃瓶收集（可盛4次）
+tips.block_taru_shouyu.name=酿造酱油的桶，用玻璃瓶收集（可盛 4 次）
 item.block_shouyu_bot.name=酱油
 item.block_shouyu_bot_2.name=酱油
 item.block_shouyu_bot_3.name=酱油
 item.block_shouyu_bot_4.name=酱油
 chinjufumod.subtitle.shouyu.name=倒入酱油
-tips.block_bot.name=可用4次
-tips.block_bot_2.name=可用3次
-tips.block_bot_3.name=可用2次
-tips.block_bot_4.name=可用1次
+tips.block_bot.name=可用 4 次
+tips.block_bot_2.name=可用 3 次
+tips.block_bot_3.name=可用 2 次
+tips.block_bot_4.name=可用 1 次
 
 item.item_food_kirimi_salmon.name=鲑鱼刺身
 item.item_food_kirimi_fish.name=生鱼刺身
@@ -2154,7 +2154,7 @@ item.block_shishiodoshi.name=添水
 tips.block_shishiodoshi.name=潜行放置时翻转，右击以开关
 
 item.block_hodagi_a_bot.name=段木
-tips.block_hodagi_a_bot.name=放置在光照等级小于等于11的地方时，会长出蘑菇
+tips.block_hodagi_a_bot.name=放置在光照等级小于等于 11 的地方时，会长出蘑菇
 item.block_taru_kinoko_f.name=蘑菇晾晒架
 tips.block_taru_kinoko.name=将蘑菇晾晒成日式高汤粉的架子，用玻璃瓶收集
 item.block_taru_konbu_f.name=海带晾晒架
@@ -2261,7 +2261,7 @@ tile.block_fencegate_kaede.name=枫木栅栏门
 tile.block_fencegate_ichoh.name=银杏木栅栏门
 
 item.block_inagi.name=晒架
-tips.block_inagi.name=可挂8棵水稻，干燥后右击以收集
+tips.block_inagi.name=可挂 8 棵水稻，干燥后右击以收集
 item.item_ine_dry.name=秸秆
 
 tile.block_button_sakura.name=樱花木按钮
@@ -2432,9 +2432,9 @@ tile.block_makibishi.name=铁蒺藜
 tips.block_makibishi.name=踩上会受到伤害
 	
 item.item_shouhou_empty.name=空白的详报
-tips.item_shouhou_empty.name=使用羽毛笔套装或台案记录100点经验
+tips.item_shouhou_empty.name=使用羽毛笔套装或台案记录 100 点经验
 item.item_shouhou.name=战斗详报
-tips.item_shouhou.name=使用后获得100点经验
+tips.item_shouhou.name=使用后获得 100 点经验
 
 item.item_toami.name=掩网
 tips.item_toami.name=向鱿鱼投掷即可抓住鱿鱼
@@ -2442,7 +2442,7 @@ item.block_ami_shikake.name=鱼笼
 tips.block_ami_shikake.name=放置在海洋或河流里即可捕鱼
 item.block_ami_youshoku.name=养殖网
 tips.block_ami_youshoku.name=用于繁殖鳕鱼、鲑鱼和热带鱼
-tips.repair_ami.name=使用线和3点经验修复
+tips.repair_ami.name=使用线和 3 点经验修复
 	
 name.farmedcod.name=养殖鳕鱼
 name.farmedsalmon.name=养殖鲑鱼
@@ -2454,12 +2454,12 @@ name.capturedtropicalfish.name=被捕获的热带鱼
 item.item_squid_raw.name=鱿鱼
 item.item_squid_cut.name=鱿鱼板
 item.item_squid_cooked.name=烤鱿鱼板
-tips.item_squid_raw.name=可分解为2个墨囊和1个墨鱼板
+tips.item_squid_raw.name=可分解为 2 个墨囊和 1 个墨鱼板
 item.block_food_donkaisen_1.name=海鲜盖浇饭
 tips.block_food_donkaisen_1.name=
 	
 tile.block_snowcore.name=小雪球
-tips.block_snowcore.name=在雪上右击以滚动变大，再将2个雪球堆在一起形成雪人
+tips.block_snowcore.name=在雪上右击以滚动变大，再将 2 个雪球堆在一起形成雪人
 item.block_snowman.name=雪人
 tips.block_snowman.name=使用胡萝卜和羊毛更换外观
 	
@@ -2496,7 +2496,7 @@ item.item_food_takenoko.name=烤竹笋
 	
 item.item_chestnuts_burr.name=栗子壳
 tile.block_chestnuts.name=栗子
-tips.block_chestnuts.name=可被分解为2个板栗和1个栗子壳
+tips.block_chestnuts.name=可被分解为 2 个板栗和 1 个栗子壳
 item.item_chestnut.name=板栗
 tips.item_chestnut.name=可以烤制后食用
 item.item_food_chestnut.name=烤板栗


### PR DESCRIPTION
<!--
要勾选下面的复选框 可以将文本[ ]改为[x]，注意别误删前后的空格。
务必认真阅读并完成此检查单。如有其他需说明的事项请写在检查单之前。
若检查单出现不会使用的情况，请查看Issues列表的 #2539 “检查单”使用说明 & 错误“检查单”使用情况报告
-->

- [x] 我已**仔细**阅读贡献指南 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已阅读并同意按 [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh) 协议发布我的作品；
- [ ] 刷新 PR 的标签/状态，有需要再点击；

---
修了一下数字前后的空格问题