### PR TITLE
Clumps 添加实体名称

### DIFF
--- a/projects/1.12.2/assets/clumps/clumps/lang/en_us.lang
+++ b/projects/1.12.2/assets/clumps/clumps/lang/en_us.lang
@@ -1,0 +1,1 @@
+entity.xp_orb_big.name=Experience Orb

--- a/projects/1.12.2/assets/clumps/clumps/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/clumps/clumps/lang/zh_cn.lang
@@ -1,0 +1,1 @@
+entity.xp_orb_big.name=经验球


### PR DESCRIPTION
1.12.2 版本的 Clumps 没有为其增加的实体`xp_orb_big`设置本地化键名，会导致 Xaero 地图的实体雷达无法显示经验球名称，故在此添加。
<!--
要勾选下面的复选框，可以将文本[ ]改为[x]，注意别误删前后的空格。
务必认真阅读并完成此检查单。如有其他需说明的事项请写在检查单之前。
若对检查单有疑惑，请查看Issues列表的 #2539 “检查单”使用说明 & 错误“检查单”使用情况报告
-->

- [x] 我已**仔细**阅读贡献指南 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已阅读并同意按 [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh) 协议发布我的作品；
- [ ] 刷新 PR 的标签/状态，有需要再点击；
