### PR TITLE
停止支持 Create 1.18 版本

### DIFF
--- a/config/packer.json
+++ b/config/packer.json
@@ -66,7 +66,9 @@
             "pack.png",
             "README.md"
         ],
-        "modNameBlackList": [],
+        "modNameBlackList": [
+            "create"
+        ],
         "domainBlackList": [],
         "noProcessNamespace": [
             "font",


### PR DESCRIPTION
理由：官方已有汉化组且与官译负责人沟通过

> Cactus_student 9:29:23
> 很抱歉打扰，Create模组1.18版本的翻译，cfpa存在翻译过时的情况（且经常会存在更新不及时的问题），在加载资源包时会影响官方翻译，请问需要这边停止支持吗？
> 
> 标杆 9:41:28
> 停止支持吧，从1.18开始create已经有完善维护了，辛苦了



<!--
要勾选下面的复选框，可以将文本[ ]改为[x]，注意别误删前后的空格。
务必认真阅读并完成此检查单。如有其他需说明的事项请写在检查单之前。
若对检查单有疑惑，请查看Issues列表的 #2539 “检查单”使用说明 & 错误“检查单”使用情况报告
-->

- [x] 刷新 PR 的标签/状态，有需要再点击；
