### PR TITLE
Energy Meters & Vaultopic - Early Inventory Management翻译提交

### DIFF
--- a/projects/1.12.2/assets/energy-meters/energymeters/lang/en_us.lang
+++ b/projects/1.12.2/assets/energy-meters/energymeters/lang/en_us.lang
@@ -1,0 +1,3 @@
+# Blocks
+tile.energymeters.meter.name=Energy Meter
+itemGroup.energymeters=Energy Meters

--- a/projects/1.12.2/assets/energy-meters/energymeters/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/energy-meters/energymeters/lang/zh_cn.lang
@@ -1,0 +1,3 @@
+# Blocks
+tile.energymeters.meter.name=电能表
+itemGroup.energymeters=电能表

--- a/projects/1.12.2/assets/vaultopic-early-inventory-management/vaultopic/lang/en_us.lang
+++ b/projects/1.12.2/assets/vaultopic-early-inventory-management/vaultopic/lang/en_us.lang
@@ -1,0 +1,11 @@
+item.vaultopic.vault_searcher.name=Vault Searcher
+item.vaultopic.view_small.name=V.I.E.W. (Vaultopic Inventory Explorer Workbot)
+item.vaultopic.view_big.name=V.I.E.W. X (Vaultopic Inventory Explorer Workbot eXtended)
+item.vaultopic.vice.name=V.I.C.E. (Vaultopic Item Crafting Entity)
+
+key.vaultopic.view=VIEW: Search
+key.vaultopic.viewlast=VIEW: Search Last
+key.vaultopic.vice=VICE: Craft
+key.vaultopic.category=Vaultopic
+
+itemGroup.vaultopic=Vaultopic

--- a/projects/1.12.2/assets/vaultopic-early-inventory-management/vaultopic/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/vaultopic-early-inventory-management/vaultopic/lang/zh_cn.lang
@@ -1,0 +1,11 @@
+item.vaultopic.vault_searcher.name=Vault 搜索器
+item.vaultopic.view_small.name=V.I.E.W. （Vaultopic 物品栏管理机器人）
+item.vaultopic.view_big.name=V.I.E.W. X （拓展 Vaultopic 物品栏管理机器人）
+item.vaultopic.vice.name=V.I.C.E. （Vaultopic 物品合成实体）
+
+key.vaultopic.view=VIEW：搜索
+key.vaultopic.viewlast=VIEW：搜索上一个
+key.vaultopic.vice=VICE：合成
+key.vaultopic.category=Vaultopic
+
+itemGroup.vaultopic=Vaultopic


### PR DESCRIPTION
<!--
要勾选下面的复选框，可以将文本[ ]改为[x]，注意别误删前后的空格。
务必认真阅读并完成此检查单。如有其他需说明的事项请写在检查单之前。
若对检查单有疑惑，请查看Issues列表的 #2539 “检查单”使用说明 & 错误“检查单”使用情况报告
-->

- [x] 我已**仔细**阅读贡献指南 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已阅读并同意按 [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh) 协议发布我的作品；
- [ ] 刷新 PR 的标签/状态，有需要再点击；

这个vaultopic确实难翻，Inventory Explorer Workbot其实直译应该翻成物品栏资源管理器工作机器人的，但是不太通顺，我就给改成物品栏管理机器人了（）还有Item Crafting Entity不知道咋翻，感觉怪怪的