### PR TITLE
Ars Oscura 翻译提交

### DIFF
--- a/projects/1.19/assets/ars-oscura/ars_oscura/lang/en_us.json
+++ b/projects/1.19/assets/ars-oscura/ars_oscura/lang/en_us.json
@@ -1,0 +1,15 @@
+{
+  "alert.ars_oscura.no_lp": "Your soul feels weak..",
+  "ars_nouveau.school.bloodmagic": "Blood Magic",
+  "ars_oscura.glyph_desc.glyph_sentient_harm": "An advanced spell, that utilizes your collected demonic will to improve your damage output.",
+  "ars_oscura.glyph_name.glyph_sentient_harm": "Sentient Harm",
+  "effect.ars_oscura.serene": "Serene",
+  "item.ars_oscura.apprentice_tome_of_blood": "Apprentice Tome of Blood",
+  "item.ars_oscura.archmage_tome_of_blood": "Archmage Tome of Blood",
+  "item.ars_oscura.mint_tea": "Mint Tea",
+  "item.ars_oscura.novice_tome_of_blood": "Novice Tome of Blood",
+  "itemGroup.ars_oscura": "Ars Oscura",
+  "living_upgrade.ars_oscura.mana_bonus": "Mana Attunement",
+  "tooltip.ars_oscura.sigil_empty": "No entity stored",
+  "tooltip.ars_oscura.sigil_with_entity": "Entity stored: %s"
+}

--- a/projects/1.19/assets/ars-oscura/ars_oscura/lang/zh_cn.json
+++ b/projects/1.19/assets/ars-oscura/ars_oscura/lang/zh_cn.json
@@ -1,0 +1,15 @@
+{
+  "alert.ars_oscura.no_lp": "你的灵魂过于虚弱……",
+  "ars_nouveau.school.bloodmagic": "血魔法",
+  "ars_oscura.glyph_desc.glyph_sentient_harm": "一个高阶法术，可使用收集到的恶魔意志提高伤害。",
+  "ars_oscura.glyph_name.glyph_sentient_harm": "感知伤害",
+  "effect.ars_oscura.serene": "宁静",
+  "item.ars_oscura.apprentice_tome_of_blood": "学徒血之宝典",
+  "item.ars_oscura.archmage_tome_of_blood": "大法师血之宝典",
+  "item.ars_oscura.mint_tea": "薄荷茶",
+  "item.ars_oscura.novice_tome_of_blood": "初学者血之宝典",
+  "itemGroup.ars_oscura": "Ars Oscura",
+  "living_upgrade.ars_oscura.mana_bonus": "魔力调谐",
+  "tooltip.ars_oscura.sigil_empty": "未存有实体",
+  "tooltip.ars_oscura.sigil_with_entity": "存有实体：%s"
+}


### PR DESCRIPTION
<!--
要勾选下面的复选框，可以将文本[ ]改为[x]，注意别误删前后的空格。
务必认真阅读并完成此检查单。如有其他需说明的事项请写在检查单之前。
若对检查单有疑惑，请查看Issues列表的 #2539 “检查单”使用说明 & 错误“检查单”使用情况报告
-->

- [x] 我已**仔细**阅读贡献指南 [CONTRIBUTING](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md)；
- [x] 我已确认英文原文（如 en_us.json）存在且完整，内容与中文对应；
- [x] 我已阅读并同意按 [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh) 协议发布我的作品；
- [ ] 刷新 PR 的标签/状态，有需要再点击；

需注意这里的三个词`Novice` `Apprentice` `Archmage`的使用和1182不同，因此没有完全参照#3133 用词