### PR TITLE
Thaumic Energistics Extended Life 翻译新增 和 Thaumic Energistics 翻译更新

### DIFF
--- a/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/en_us.lang
+++ b/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/en_us.lang
@@ -1,0 +1,157 @@
+﻿# Creative Tab
+itemGroup.ThaumicEnergistics=Thaumic Energistics
+
+# Blocks
+tile.thaumicenergistics.infusion_provider.name=Essentia Infusion Provider
+tile.thaumicenergistics.arcane_assembler.name=Arcane Assembler
+
+# Items
+item.thaumicenergistics.diffusion_core.name=Diffusion Core
+item.thaumicenergistics.coalescence_core.name=Coalescence Core
+
+item.thaumicenergistics.essentia_component_1k.name=1k ME Essentia Storage Component
+item.thaumicenergistics.essentia_component_4k.name=4k ME Essentia Storage Component
+item.thaumicenergistics.essentia_component_16k.name=16k ME Essentia Storage Component
+item.thaumicenergistics.essentia_component_64k.name=64k ME Essentia Storage Component
+
+item.thaumicenergistics.essentia_cell_1k.name=1k ME Essentia Storage Cell
+item.thaumicenergistics.essentia_cell_4k.name=4k ME Essentia Storage Cell
+item.thaumicenergistics.essentia_cell_16k.name=16k ME Essentia Storage Cell
+item.thaumicenergistics.essentia_cell_64k.name=64k ME Essentia Storage Cell
+item.thaumicenergistics.essentia_cell_creative.name=Creative ME Essentia Storage Cell
+
+item.thaumicenergistics.essentia_import.name=ME Essentia Import Bus
+item.thaumicenergistics.essentia_export.name=ME Essentia Export Bus
+item.thaumicenergistics.essentia_storage.name=ME Essentia Storage Bus
+item.thaumicenergistics.essentia_terminal.name=ME Essentia Terminal
+item.thaumicenergistics.arcane_terminal.name=Arcane Crafting Terminal
+item.thaumicenergistics.arcane_inscriber.name=Arcane Inscriber
+
+item.thaumicenergistics.upgrade_arcane.name=Arcane Charging Upgrade
+item.thaumicenergistics.knowledge_core.name=Knowledge Core
+item.thaumicenergistics.blank_knowledge_core.name=Blank Knowledge Core
+
+# Tooltips
+tooltip.thaumicenergistics.wip=WORK IN PROGRESS, DO NOT USE
+tooltip.thaumicenergistics.device_online=Device Online
+tooltip.thaumicenergistics.device_offline=Device Offline
+tooltip.thaumicenergistics.device_missing_channel=Device Missing Channel
+tooltip.thaumicenergistics.arcane_assembler.idle=Status: idle
+tooltip.thaumicenergistics.arcane_assembler.prep=Status: prep
+tooltip.thaumicenergistics.arcane_assembler.busy=Status: busy
+tooltip.thaumicenergistics.arcane_assembler.progress=Progress:
+tooltip.thaumicenergistics.arcane_assembler.no_aspect=Error: out of aspect
+tooltip.thaumicenergistics.arcane_assembler.no_vis=Error: out of Vis
+
+# GUI
+gui.thaumicenergistics.essentia_import_bus=ME Essentia Import Bus
+gui.thaumicenergistics.essentia_export_bus=ME Essentia Export Bus
+gui.thaumicenergistics.essentia_storage_bus=ME Essentia Storage Bus
+gui.thaumicenergistics.essentia_terminal=Essentia Terminal
+gui.thaumicenergistics.arcane_terminal=Arcane Terminal
+gui.thaumicenergistics.arcane_inscriber=Arcane Inscriber
+
+gui.thaumicenergistics.vis_required=Vis cost: %s
+gui.thaumicenergistics.vis_required_out_of=Vis cost: %s/%s
+gui.thaumicenergistics.vis_available=%s Available
+gui.thaumicenergistics.vis_discount=%s%% Discount
+
+gui.thaumicenergistics.insert_knowledge_core=Insert a Knowledge Core
+gui.thaumicenergistics.knowledge_core_is_blank=The Knowledge Core is blank
+gui.thaumicenergistics.recipe_already_stored=The recipe is already stored
+gui.thaumicenergistics.recipe_not_arcane=The recipe is not arcane
+gui.thaumicenergistics.no_recipe=No recipe selected
+
+gui.thaumicenergistics.out_of_aspect=Out of aspect!
+gui.thaumicenergistics.out_of_vis=Out of vis!
+
+card.tinkerae.name=Tinker with Matter/Energy
+card.tinkerae.text=Experiment with converting Essentia into Energy similar to your current Matter/Energy network. Gain 10-25 Energistics.
+
+# FROM THAUMCRAFT en_US.lang
+# BEST TO RECHECK THE LATEST LANG FILE FOR CHANGED FORMATTING
+#
+# Special formatting codes:
+# <BR> or <BR/>         Paragraph break (<BR/> is included for people using XML for their localization)
+# <LINE> or <LINE/>     Insert a fancy centered linebreak between sections of text.
+# <DIV> or <DIV/>     Insert a fancy left-justified linebreak between sections of text.
+# <PAGE> or <PAGE/>     Skip to a new page.
+# <IMG>...</IMG>  Insert a centered image into text. Parameters are separated by ':' and are:
+#                    - mod resource location name
+#                    - png file location (assumed to be a 256x256 texture, a sub-image will be grabbed from this png as specified below)
+#                    - x location of sub-image in png
+#                    - y location of sub-image in png
+#                    - x size of sub-image (255 if full x size of png must be used)
+#                    - y size of sub-image (255 if full y size of png must be used)
+#                    - scaling - 1.0 for normal 256x256 images, or smaller for proportionately smaller .png files (a 16x16 image will be 0.0625)
+#               Examples:
+#                   <IMG>thaumcraft:textures/gui/gui_researchbook.png:24:184:96:4:1.0</IMG>   <-- line break image as used in <LINE> above
+#                   <IMG>thaumcraft:textures/items/alumentum.png:0:0:255:255:0.0625</IMG>     <-- alumentum item icon
+
+# Research Category
+tc.research_category.THAUMICENERGISTICS=Energistics
+
+# Research Basics
+research.base_energistics.title=Thaumic Energistics
+research.base_energistics.stage.1=As both a scientist and an arcane scholar, I have postulated that it must be possible to combine technology and magic in a stable and productive way.<BR>I should study the principals of matter-energy conversion in detail to accomplish this. It is likely there are aspects of Thaumaturgy that can accomplish this, as well as technology capable of doing the same.<BR>This will require extensive study, but I am sure that it will be a worthwhile investment of my time.
+
+# Research Digisentia
+research.digisentia.title=Digi-Sentia
+research.digisentia.stage.1=Having discovered how to distill essentia, it occurs to me that I may be able store it digitally.<BR>Examining the §lFormation Core§r and §lAnnihilation Core§r I realize that with some minor modifications they could serve as a means to convert essentia to and from a digital format.<BR>However, due to the corrosive nature of certain types of essentia, a layer of quicksilver around the circuitry is required to prevent decay.
+research.digisentia.stage.2=§lDiffusion Core§r<BR>The relatively high volatility and immense energy in distilled essentia requires that it first be diffused then digitized. A buffer chamber of some kind will likely be required to hold the diffused essentia.<PAGE><LINE>§lCoalescence Core§r<BR>Compresses and binds re-materialized essentia diffusion back into its raw form. A buffer chamber will also likely be needed.
+
+# Research Digisentia Storage
+# 1k
+research.essentiastorage1k.title=Digisentia Storage
+research.essentiastorage1k.stage.1=Upon inspecting existing digital storage mediums I have concluded that I can in-fact store digitized essentia.<BR>By infusing §lCertus Quartz§r with §lSalis Mundus§r, it should gain the ability to store the essentia, which remains remarkably active even in digital form.<BR>I theorize that the higher the concentration of §lSalis Mundus§r, the more it should be able to store, although there are inherit limits as to how much the quartz itself can store.
+research.essentiastorage1k.stage.2=I have managed to create a storage device capable of storing a small amount of essentia digitally, maybe I could combine multiple components for increased storage?
+# 4k
+research.essentiastorage4k.title=Bigger Digisentia Storage
+research.essentiastorage4k.stage.1=Maybe I can use some different processing components to combine multiple storage components together
+research.essentiastorage4k.stage.2=I can now store a decent amount of essentia digitally by using some calculation processors to allow the components to talk to each other
+# 16k
+research.essentiastorage16k.title=Larger Digisentia Storage
+research.essentiastorage16k.stage.1=Like I did with my previous attempt to get bigger storage components I can use some high end processors to combine multiple storage components together
+research.essentiastorage16k.stage.2=Using another type of processor, I can now store 16x the amount of essentia on a storage component than when I started with my crude storage system
+# 64k
+research.essentiastorage64k.title=Massive Digisentia Storage
+research.essentiastorage64k.stage.1=My current storage needs are not enough, I hope I can still combine storage components to create a larger one while taking up the same space...
+research.essentiastorage64k.stage.2=I can now store massive amounts of essentia on a storage component, but I feel that this is the limit of the technology
+
+# Research Essentia Buses
+research.essentiabuses.title=Digisentia Transportation
+research.essentiabuses.stage.1=Now that I have the components to safely transport essentia with my ME system, I can now work on creating buses for essentia.
+research.essentiabuses.stage.2=I can now make Import, Export, and Storage Buses. They all function exactly like their item counterparts.
+
+# Research Essentia Terminal
+research.essentiaterminal.title=Essentia Monitoring
+research.essentiaterminal.stage.1=While I can now digitize essentia, I have realized this means I can no longer observe the quantities of essentia I have digitalized - an urgent problem.
+research.essentiaterminal.stage.2=The ME Essentia Terminal allows me to see all essentia my ME network can access. Additionally, I can insert and extract essentia with phials through it.
+
+# Research Infusion Provider
+research.infusionprovider.title=Infusion Provider
+research.infusionprovider.stage.1=While being able to manipulate essentia with my ME system has proven invaluable, I am frustrated with the process required for Infusion - I have to extract all my essentia into jars on-site. Perhaps if I could expose my essentia to the Runic Matrix similar to the Essentia Terminal...
+research.infusionprovider.stage.2=Success! The Essentia Infusion Provider will expose the entire ME network's essentia to the Infusion process! As a bonus, it also works with my ME Essentia Storage Buses, allowing me to create essentia subnetworks, should I ever need those.
+
+# Research Arcane Crafting Terminal
+research.arcaneterminal.title=Arcane Crafting Terminal
+research.arcaneterminal.stage.1=Having to hop back and forth between my ME system and my Arcane Workbench for every craft is getting frustrating. While it is vastly more complex than a mere Crafting Terminal, using the same principles, I should be able to hook my Arcane Workbench into my ME system.
+research.arcaneterminal.stage.2=The Arcane Crafting Terminal allows my Arcane Workbench to take full advantage of my ME system.
+research.arcaneterminal.addenda.1=I can upgrade my Arcane Crafting Terminal with the Arcane Charging Upgrade to allow it to access and draw vis from all neighboring chunks.
+
+# Research Arcane Assembler
+research.arcaneassembler.title=Arcane Assembler
+research.arcaneassembler.stage.1=While being able to manually craft arcane items with my ME network is very helpful, the true power of ME is its auto-crafting ability. I should look into some way to make a Molecular Assembler able to craft arcane objects.
+research.arcaneassembler.stage.2=Everything ought to work - it can get the items, the vis, the Essentia crystals, the power. Yet it doesn't even attempt to craft! I have invented nothing more than a, albeit quite heavy, paperweight. A paperweight which can be augmented with multiple Acceleration Cards. This has been a massive disappointment.
+research.arcaneassembler.addenda.1=I can upgrade my Arcane Assembler with the Arcane Charging Upgrade to allow it to access and draw vis from all neighbouring chunks.
+research.arcaneassembler.addenda.2=Now that I have seen the Arcane Assembler in use, I have realised a pair of problems - the first being that Vis is consumed at an alarming rate while auto-crafting, often slowing down the process massively, and the second being that Vis Crystals are not shown in the recipe cost. I will need to figure out ways to avoid both of these problems to efficiently auto-craft.
+
+# Research Knowledge Core
+research.knowledgecore.title=Knowledge Core
+research.knowledgecore.stage.1=I've been thinking about my current paperweight, the Arcane Assembler. Perhaps the issue is that it doesn't know how to craft - it hasn't spent hours researching, after all. I should look into ways to allow the Arcane Assembler to research.
+research.knowledgecore.stage.2=Eureka! I don't need to have the Arcane Assembler research - likely an impossible task - I merely need to create something that can remember a craft I've done, and do it exactly the same way. A zombie brain is perfect for this - all I have to do is teach the brain to do exactly the recipe I show it.
+
+# Research Arcane Inscriber
+research.arcaneinscriber.title=Arcane Inscriber
+research.arcaneinscriber.stage.1=It appears the undead are not very bright. I've been trying to teach this Knowledge Core how to craft for a while now, yet it hasn't learned anything. I need to find a way to force the Knowledge Core to learn.
+research.arcaneinscriber.stage.2=Basing my design off of an ME Pattern Terminal, I have managed to design a kind of terminal that can teach recipes to a Knowledge Core. I simply load the recipe into the grid and then save it! I can also examine what recipes I have saved to a Knowledge Core, and if so desired, erase recipes from the zombie's memory. While a single zombie brain is limited in how many recipes it can remember, zombies are plentiful.

--- a/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/zh_cn.lang
@@ -142,7 +142,7 @@ research.arcaneterminal.addenda.1=我可以用奥术充能升级来升级我的�
 # Research Arcane Assembler
 research.arcaneassembler.title=奥术装配室
 research.arcaneassembler.stage.1=尽管ME网络对手动合成奥术物品很有用，但ME的真正力量在于它的自动合成。我应该想办法让分子装配室能够合成奥术物品。
-research.arcaneassembler.stage.2=一切都应是正常的——它可以获得物品、Vis、 魔力水晶碎片和能量。然而，它甚至没有尝试合成！我发明的不过是一个沉重的镇纸，一个可以使用几张加速卡强化的镇纸。这令我非常失望。
+research.arcaneassembler.stage.2=一切都应是正常的——它可以获得物品、Vis、魔力水晶碎片和能量。然而，它甚至没有尝试合成！我发明的不过是一个沉重的镇纸，一个可以使用几张加速卡强化的镇纸。这令我非常失望。
 research.arcaneassembler.addenda.1=我可以用奥术充能升级来升级我的奥术装配室，以允许它从所有邻近的区块中抽取Vis。
 research.arcaneassembler.addenda.2=现在我看到了奥术装配室的使用情况，我意识到了两个问题。第一个问题是自动合成时，Vis的消耗速度惊人，经常会大大减慢合成；第二个问题是魔力水晶碎片没有显示在合成消耗中。我需要想办法来避免这两个问题，以便高效地进行自动合成。
 

--- a/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/zh_cn.lang
@@ -98,7 +98,7 @@ research.base_energistics.stage.1=作为一名科学家兼神秘学者，我设�
 # Research Digisentia
 research.digisentia.title=源质数位化
 research.digisentia.stage.1=完成要素蒸馏的研究后，我突然想到，也许能将其数位化存储。<BR>测试§l成型核心§r和§l破坏核心§r时，我意识到只要稍加修改，它们就可以作为将源质与数字格式间相互转换的一种手段。<BR>由于某些源质天生具有腐蚀性，需要在电路表面覆上一层水银以防止腐蚀。
-research.digisentia.stage.2=§l扩散核心§r<BR>液态源质具有相对较高的波动性和巨大的能量，这使得需先将其扩散稀释，然后再数位化。这时候就需要某种缓冲器来容纳这些扩散的源质。<PAGE><LINE>§l聚集核心§r<BR>压缩并将分散的源质重塑凝为原先的液态。很可能也需要这样一个缓冲器。
+research.digisentia.stage.2=§l扩散核心§r<BR>液态源质具有相对较高的挥发性和巨大的能量，这使得需先将其扩散稀释，然后再数位化。这时候就需要某种缓冲器来容纳这些扩散的源质。<PAGE><LINE>§l聚集核心§r<BR>压缩并将分散的源质重塑凝为原先的液态。很可能也需要这样一个缓冲器。
 
 # Research Digisentia Storage
 # 1k

--- a/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/zh_cn.lang
@@ -66,7 +66,7 @@ gui.thaumicenergistics.out_of_aspect=缺少源质！
 gui.thaumicenergistics.out_of_vis=缺少Vis！
 
 card.tinkerae.name=捣鼓ME网络
-card.tinkerae.text=尝试将源质转化为能量，类似于你现在的ME网络所做的。获得 10-25 能源学。
+card.tinkerae.text=尝试将源质转化为能量，就像你的ME网络一样。获得10到25点 能源学 进度。
 
 # FROM THAUMCRAFT en_US.lang
 # BEST TO RECHECK THE LATEST LANG FILE FOR CHANGED FORMATTING
@@ -97,25 +97,25 @@ research.base_energistics.stage.1=作为一名科学家兼神秘学者，我设�
 
 # Research Digisentia
 research.digisentia.title=源质数位化
-research.digisentia.stage.1=完成要素蒸馏的研究后，我突然想到，我可能能将其数位化存储。<BR>测试§l成型核心§r和§l破坏核心§r时，我意识到只要稍加修改，它们就可以作为将源质与数字格式间相互转换的一种手段。<BR>由于某些源质天生具有腐蚀性，需要在电路表面覆上一层水银以防止腐蚀。
+research.digisentia.stage.1=完成要素蒸馏的研究后，我突然想到，也许能将其数位化存储。<BR>测试§l成型核心§r和§l破坏核心§r时，我意识到只要稍加修改，它们就可以作为将源质与数字格式间相互转换的一种手段。<BR>由于某些源质天生具有腐蚀性，需要在电路表面覆上一层水银以防止腐蚀。
 research.digisentia.stage.2=§l扩散核心§r<BR>液态源质具有相对较高的波动性和巨大的能量，这使得需先将其扩散稀释，然后再数位化。这时候就需要某种缓冲器来容纳这些扩散的源质。<PAGE><LINE>§l聚集核心§r<BR>压缩并将分散的源质重塑凝为原先的液态。很可能也需要这样一个缓冲器。
 
 # Research Digisentia Storage
 # 1k
 research.essentiastorage1k.title=数位化源质存储
 research.essentiastorage1k.stage.1=在检查了现有的数位化存储介质后，我得出结论，我实际上可以存储数位化的源质。<BR>§l赛特斯石英§r通过注入§l世界盐§r，就应该会获得存储源质的能力，在数位化的格式下也十分有效。<BR>我认为注入的§l世界盐§r的浓度越高，它能储存的东西应该就越多，尽管这一数值还会受到石英本身的限制。
-research.essentiastorage1k.stage.2=我已经成功地制造出了一个能够数位化存储少量源质的存储元件，也许我可以组合多个组件以增加存储空间？
+research.essentiastorage1k.stage.2=我已经成功地制造出了一个能够数位化存储少量源质的存储元件，也许可以组合多个组件以增加存储空间？
 # 4k
 research.essentiastorage4k.title=加大数位化源质存储
 research.essentiastorage4k.stage.1=也许我可以使用一些不同的处理器，将多个存储组件组合在一起。
 research.essentiastorage4k.stage.2=通过使用一些运算处理器，让各个组件之间能够相互通信，我现在可以数位化存储相当数量的源质。
 # 16k
 research.essentiastorage16k.title=大量数位化源质存储
-research.essentiastorage16k.stage.1=就像我之前试图获得更大的存储组件一样，我可以使用一些高端处理器将多个存储组件组合在一起。
+research.essentiastorage16k.stage.1=就像之前试图获得更大的存储组件一样，我可以使用一些高端处理器将多个存储组件组合在一起。
 research.essentiastorage16k.stage.2=通过使用另一种处理器，我现在可以存储刚开始使用简陋存储网络时16倍的源质数量于一个存储组件中。
 # 64k
 research.essentiastorage64k.title=海量数位化源质存储
-research.essentiastorage64k.stage.1=我目前的存储需求还未被满足，我希望我仍能将存储组件组合起来，在占用相同空间的情况下创造一个更大的存储组件……
+research.essentiastorage64k.stage.1=我目前的存储需求还未被满足。希望我仍能将存储组件组合起来，在占用相同空间的情况下创造一个更大的存储组件……
 research.essentiastorage64k.stage.2=我现在可以在存储组件上存储大量的源质，但我觉得这已经是这项技术的极限了。
 
 # Research Essentia Buses
@@ -125,12 +125,12 @@ research.essentiabuses.stage.2=我现在可以合成源质输入、输出和存�
 
 # Research Essentia Terminal
 research.essentiaterminal.title=源质监控
-research.essentiaterminal.stage.1=虽然我现在可以将源质数位化，但我意识到这意味着我无法再观察到我已经数位化的源质的数量了——这是个紧迫的问题。
+research.essentiaterminal.stage.1=虽然我现在可以将源质数位化，但我意识到这意味着我无法再观察到已经数位化的源质的数量了——这是个紧迫的问题。
 research.essentiaterminal.stage.2=通过ME源质终端，我可以看到ME网络可访问的所有源质。此外，我还可以通过它用玻璃安瓿存入和取出要素。
 
 # Research Infusion Provider
 research.infusionprovider.title=注魔供应器
-research.infusionprovider.stage.1=虽然能够用我的ME网络操纵源质已非常宝贵，但我对注魔所需的过程感到失望——我必须现场将所有要素提取到源质罐子里。如果我能把我的源质供应给符文矩阵，就像源质终端一样……
+research.infusionprovider.stage.1=虽然能够用我的ME网络操纵源质已非常宝贵，但我对注魔所需的过程感到失望——我必须现场将所有要素提取到源质罐子里。如果能把我的源质供应给符文矩阵，就像源质终端一样的话……
 research.infusionprovider.stage.2=大功告成！注魔供应器可将整个ME网络的源质供应给注魔进程！此外，它还能与我的ME源质存储总线配合使用，让我可以创建源质子网络，以备不时之需。
 
 # Research Arcane Crafting Terminal
@@ -148,10 +148,10 @@ research.arcaneassembler.addenda.2=现在我看到了奥术装配室的使用情
 
 # Research Knowledge Core
 research.knowledgecore.title=知识核心
-research.knowledgecore.stage.1=我一直在对我现在的镇纸思考——奥术装配室。也许问题在于它不知道如何合成——毕竟它没有花几个小时来研究。我应该想办法让奥术装配室进行研究。
-research.knowledgecore.stage.2=我知道了！我不需要让奥术装配室进行研究——这很可能是一项不可能完成的任务。我只需要创造一个能记住我做过的合成的东西，并以完全相同的方式进行合成。僵尸之脑就非常适合做这件事。而我所要做的，就是教它完全按照我展示给它的配方去做。
+research.knowledgecore.stage.1=我一直在对现在的镇纸思考——奥术装配室。也许问题在于它不知道如何合成——毕竟它没有花几个小时来研究。我应该想办法让奥术装配室进行研究。
+research.knowledgecore.stage.2=我知道了！我不需要让奥术装配室进行研究——这很可能是一项不可能完成的任务，只需创造一个能记住我做过的合成的东西，并以完全相同的方式进行合成。僵尸之脑就非常适合做这件事。而我所要做的，就是教它完全按照我展示给它的配方去做。
 
 # Research Arcane Inscriber
 research.arcaneinscriber.title=奥术记录仪
-research.arcaneinscriber.stage.1=看来亡灵不是很聪明。我试着教这个知识核心合成已经有一段时间了，但它什么也没学会。我得想办法强迫它学习。
-research.arcaneinscriber.stage.2=在ME样板终端的基础上，我成功地设计出了一种可以向知识核心传授合成配方的终端。我只需将配方载入网格，然后保存即可！我还可以查看我保存到知识核心中的配方。如果需要的话，还可以从它的记忆中删除配方。虽然单个僵尸之脑能记住的配方有限，但它数量很多。
+research.arcaneinscriber.stage.1=看来亡灵不是很聪明。我试着教这个知识核心合成已经有一段时间了，但它什么也没学会。得想办法强迫它学习。
+research.arcaneinscriber.stage.2=在ME样板终端的基础上，我成功地设计出了一种可以向知识核心传授合成配方的终端。只需将配方载入网格，然后保存即可！我还可以查看保存到知识核心中的配方。如果需要的话，还可以从它的记忆中删除配方。虽然单个僵尸之脑能记住的配方有限，但它数量很多。

--- a/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/zh_cn.lang
@@ -25,7 +25,7 @@ item.thaumicenergistics.essentia_export.name=ME源质输出总线
 item.thaumicenergistics.essentia_storage.name=ME源质存储总线
 item.thaumicenergistics.essentia_terminal.name=ME源质终端
 item.thaumicenergistics.arcane_terminal.name=奥术合成终端
-item.thaumicenergistics.arcane_inscriber.name=奥术装配室
+item.thaumicenergistics.arcane_inscriber.name=奥术记录仪
 
 item.thaumicenergistics.upgrade_arcane.name=奥术充能升级
 item.thaumicenergistics.knowledge_core.name=知识核心

--- a/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/thaumic-energistics-extended-life/thaumicenergistics/lang/zh_cn.lang
@@ -1,0 +1,157 @@
+﻿# Creative Tab
+itemGroup.ThaumicEnergistics=神秘能源
+
+# Blocks
+tile.thaumicenergistics.infusion_provider.name=注魔供应器
+tile.thaumicenergistics.arcane_assembler.name=奥术装配室
+
+# Items
+item.thaumicenergistics.diffusion_core.name=扩散核心
+item.thaumicenergistics.coalescence_core.name=聚集核心
+
+item.thaumicenergistics.essentia_component_1k.name=1k-ME源质存储组件
+item.thaumicenergistics.essentia_component_4k.name=4k-ME源质存储组件
+item.thaumicenergistics.essentia_component_16k.name=16k-ME源质存储组件
+item.thaumicenergistics.essentia_component_64k.name=64k-ME源质存储组件
+
+item.thaumicenergistics.essentia_cell_1k.name=1k-ME源质存储元件
+item.thaumicenergistics.essentia_cell_4k.name=4k-ME源质存储元件
+item.thaumicenergistics.essentia_cell_16k.name=16k-ME源质存储元件
+item.thaumicenergistics.essentia_cell_64k.name=64k-ME源质存储元件
+item.thaumicenergistics.essentia_cell_creative.name=创造型ME源质存储元件
+
+item.thaumicenergistics.essentia_import.name=ME源质输入总线
+item.thaumicenergistics.essentia_export.name=ME源质输出总线
+item.thaumicenergistics.essentia_storage.name=ME源质存储总线
+item.thaumicenergistics.essentia_terminal.name=ME源质终端
+item.thaumicenergistics.arcane_terminal.name=奥术合成终端
+item.thaumicenergistics.arcane_inscriber.name=奥术装配室
+
+item.thaumicenergistics.upgrade_arcane.name=奥术充能升级
+item.thaumicenergistics.knowledge_core.name=知识核心
+item.thaumicenergistics.blank_knowledge_core.name=空白知识核心
+
+# Tooltips
+tooltip.thaumicenergistics.wip=未完成，请勿使用
+tooltip.thaumicenergistics.device_online=设备开启
+tooltip.thaumicenergistics.device_offline=设备关闭
+tooltip.thaumicenergistics.device_missing_channel=设备缺少频道
+tooltip.thaumicenergistics.arcane_assembler.idle=状态：闲置
+tooltip.thaumicenergistics.arcane_assembler.prep=状态：准备
+tooltip.thaumicenergistics.arcane_assembler.busy=状态：繁忙
+tooltip.thaumicenergistics.arcane_assembler.progress=正在处理：
+tooltip.thaumicenergistics.arcane_assembler.no_aspect=错误：缺少源质
+tooltip.thaumicenergistics.arcane_assembler.no_vis=错误：缺少Vis
+
+# GUI
+gui.thaumicenergistics.essentia_import_bus=ME源质输入总线
+gui.thaumicenergistics.essentia_export_bus=ME源质输出总线
+gui.thaumicenergistics.essentia_storage_bus=ME源质存储总线
+gui.thaumicenergistics.essentia_terminal=ME源质终端
+gui.thaumicenergistics.arcane_terminal=奥术合成终端
+gui.thaumicenergistics.arcane_inscriber=奥术记录仪
+
+gui.thaumicenergistics.vis_required=Vis消耗：%s
+gui.thaumicenergistics.vis_required_out_of=Vis消耗：%s/%s
+gui.thaumicenergistics.vis_available=%s 可用
+gui.thaumicenergistics.vis_discount=%s%% 减免
+
+gui.thaumicenergistics.insert_knowledge_core=插入一个知识核心
+gui.thaumicenergistics.knowledge_core_is_blank=知识核心空白
+gui.thaumicenergistics.recipe_already_stored=配方已存储
+gui.thaumicenergistics.recipe_not_arcane=非奥术配方
+gui.thaumicenergistics.no_recipe=无选中配方
+
+gui.thaumicenergistics.out_of_aspect=缺少源质！
+gui.thaumicenergistics.out_of_vis=缺少Vis！
+
+card.tinkerae.name=捣鼓ME网络
+card.tinkerae.text=尝试将源质转化为能量，类似于你现在的ME网络所做的。获得 10-25 能源学。
+
+# FROM THAUMCRAFT en_US.lang
+# BEST TO RECHECK THE LATEST LANG FILE FOR CHANGED FORMATTING
+#
+# Special formatting codes:
+# <BR> or <BR/>         Paragraph break (<BR/> is included for people using XML for their localization)
+# <LINE> or <LINE/>     Insert a fancy centered linebreak between sections of text.
+# <DIV> or <DIV/>     Insert a fancy left-justified linebreak between sections of text.
+# <PAGE> or <PAGE/>     Skip to a new page.
+# <IMG>...</IMG>  Insert a centered image into text. Parameters are separated by ':' and are:
+#                    - mod resource location name
+#                    - png file location (assumed to be a 256x256 texture, a sub-image will be grabbed from this png as specified below)
+#                    - x location of sub-image in png
+#                    - y location of sub-image in png
+#                    - x size of sub-image (255 if full x size of png must be used)
+#                    - y size of sub-image (255 if full y size of png must be used)
+#                    - scaling - 1.0 for normal 256x256 images, or smaller for proportionately smaller .png files (a 16x16 image will be 0.0625)
+#               Examples:
+#                   <IMG>thaumcraft:textures/gui/gui_researchbook.png:24:184:96:4:1.0</IMG>   <-- line break image as used in <LINE> above
+#                   <IMG>thaumcraft:textures/items/alumentum.png:0:0:255:255:0.0625</IMG>     <-- alumentum item icon
+
+# Research Category
+tc.research_category.THAUMICENERGISTICS=能源学
+
+# Research Basics
+research.base_energistics.title=神秘能源
+research.base_energistics.stage.1=作为一名科学家兼神秘学者，我设想有方法将科技与魔法稳定且有效地结合起来。<BR>我应该仔细研究物质和能量互相转换的原理来实现它。似乎神秘学中有要素可以做到，科技中也有方法做到同样的事。<BR>这需要进行大量的研究，但我相信这样投入时间是值得的。
+
+# Research Digisentia
+research.digisentia.title=源质数位化
+research.digisentia.stage.1=完成要素蒸馏的研究后，我突然想到，我可能能将其数位化存储。<BR>测试§l成型核心§r和§l破坏核心§r时，我意识到只要稍加修改，它们就可以作为将源质与数字格式间相互转换的一种手段。<BR>由于某些源质天生具有腐蚀性，需要在电路表面覆上一层水银以防止腐蚀。
+research.digisentia.stage.2=§l扩散核心§r<BR>液态源质具有相对较高的波动性和巨大的能量，这使得需先将其扩散稀释，然后再数位化。这时候就需要某种缓冲器来容纳这些扩散的源质。<PAGE><LINE>§l聚集核心§r<BR>压缩并将分散的源质重塑凝为原先的液态。很可能也需要这样一个缓冲器。
+
+# Research Digisentia Storage
+# 1k
+research.essentiastorage1k.title=数位化源质存储
+research.essentiastorage1k.stage.1=在检查了现有的数位化存储介质后，我得出结论，我实际上可以存储数位化的源质。<BR>§l赛特斯石英§r通过注入§l世界盐§r，就应该会获得存储源质的能力，在数位化的格式下也十分有效。<BR>我认为注入的§l世界盐§r的浓度越高，它能储存的东西应该就越多，尽管这一数值还会受到石英本身的限制。
+research.essentiastorage1k.stage.2=我已经成功地制造出了一个能够数位化存储少量源质的存储元件，也许我可以组合多个组件以增加存储空间？
+# 4k
+research.essentiastorage4k.title=加大数位化源质存储
+research.essentiastorage4k.stage.1=也许我可以使用一些不同的处理器，将多个存储组件组合在一起。
+research.essentiastorage4k.stage.2=通过使用一些运算处理器，让各个组件之间能够相互通信，我现在可以数位化存储相当数量的源质。
+# 16k
+research.essentiastorage16k.title=大量数位化源质存储
+research.essentiastorage16k.stage.1=就像我之前试图获得更大的存储组件一样，我可以使用一些高端处理器将多个存储组件组合在一起。
+research.essentiastorage16k.stage.2=通过使用另一种处理器，我现在可以存储刚开始使用简陋存储网络时16倍的源质数量于一个存储组件中。
+# 64k
+research.essentiastorage64k.title=海量数位化源质存储
+research.essentiastorage64k.stage.1=我目前的存储需求还未被满足，我希望我仍能将存储组件组合起来，在占用相同空间的情况下创造一个更大的存储组件……
+research.essentiastorage64k.stage.2=我现在可以在存储组件上存储大量的源质，但我觉得这已经是这项技术的极限了。
+
+# Research Essentia Buses
+research.essentiabuses.title=数位化源质传输
+research.essentiabuses.stage.1=我现在已经拥有了用ME网络安全运输源质的存储组件，可以着手于创造源质总线了。
+research.essentiabuses.stage.2=我现在可以合成源质输入、输出和存储总线了。它们的功能与物品总线完全相同。
+
+# Research Essentia Terminal
+research.essentiaterminal.title=源质监控
+research.essentiaterminal.stage.1=虽然我现在可以将源质数位化，但我意识到这意味着我无法再观察到我已经数位化的源质的数量了——这是个紧迫的问题。
+research.essentiaterminal.stage.2=通过ME源质终端，我可以看到ME网络可访问的所有源质。此外，我还可以通过它用玻璃安瓿存入和取出要素。
+
+# Research Infusion Provider
+research.infusionprovider.title=注魔供应器
+research.infusionprovider.stage.1=虽然能够用我的ME网络操纵源质已非常宝贵，但我对注魔所需的过程感到失望——我必须现场将所有要素提取到源质罐子里。如果我能把我的源质供应给符文矩阵，就像源质终端一样……
+research.infusionprovider.stage.2=大功告成！注魔供应器可将整个ME网络的源质供应给注魔进程！此外，它还能与我的ME源质存储总线配合使用，让我可以创建源质子网络，以备不时之需。
+
+# Research Arcane Crafting Terminal
+research.arcaneterminal.title=奥术合成终端
+research.arcaneterminal.stage.1=每次合成，我都不得不在我的ME网络和奥术工作台之间跳来跳去，真令人丧气。虽然它比单纯的合成终端复杂得多，但我应该可以用相同的原理将我的奥术工作台连接到ME网络上。
+research.arcaneterminal.stage.2=奥术合成终端可以让我的奥术工作台充分利用我的ME网络。
+research.arcaneterminal.addenda.1=我可以用奥术充能升级来升级我的奥术合成终端，以允许它从所有邻近的区块中抽取Vis。
+
+# Research Arcane Assembler
+research.arcaneassembler.title=奥术装配室
+research.arcaneassembler.stage.1=尽管ME网络对手动合成奥术物品很有用，但ME的真正力量在于它的自动合成。我应该想办法让分子装配室能够合成奥术物品。
+research.arcaneassembler.stage.2=一切都应是正常的——它可以获得物品、Vis、 魔力水晶碎片和能量。然而，它甚至没有尝试合成！我发明的不过是一个沉重的镇纸，一个可以使用几张加速卡强化的镇纸。这令我非常失望。
+research.arcaneassembler.addenda.1=我可以用奥术充能升级来升级我的奥术装配室，以允许它从所有邻近的区块中抽取Vis。
+research.arcaneassembler.addenda.2=现在我看到了奥术装配室的使用情况，我意识到了两个问题。第一个问题是自动合成时，Vis的消耗速度惊人，经常会大大减慢合成；第二个问题是魔力水晶碎片没有显示在合成消耗中。我需要想办法来避免这两个问题，以便高效地进行自动合成。
+
+# Research Knowledge Core
+research.knowledgecore.title=知识核心
+research.knowledgecore.stage.1=我一直在对我现在的镇纸思考——奥术装配室。也许问题在于它不知道如何合成——毕竟它没有花几个小时来研究。我应该想办法让奥术装配室进行研究。
+research.knowledgecore.stage.2=我知道了！我不需要让奥术装配室进行研究——这很可能是一项不可能完成的任务。我只需要创造一个能记住我做过的合成的东西，并以完全相同的方式进行合成。僵尸之脑就非常适合做这件事。而我所要做的，就是教它完全按照我展示给它的配方去做。
+
+# Research Arcane Inscriber
+research.arcaneinscriber.title=奥术记录仪
+research.arcaneinscriber.stage.1=看来亡灵不是很聪明。我试着教这个知识核心合成已经有一段时间了，但它什么也没学会。我得想办法强迫它学习。
+research.arcaneinscriber.stage.2=在ME样板终端的基础上，我成功地设计出了一种可以向知识核心传授合成配方的终端。我只需将配方载入网格，然后保存即可！我还可以查看我保存到知识核心中的配方。如果需要的话，还可以从它的记忆中删除配方。虽然单个僵尸之脑能记住的配方有限，但它数量很多。

--- a/projects/1.12.2/assets/thaumic-energistics/thaumicenergistics/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/thaumic-energistics/thaumicenergistics/lang/zh_cn.lang
@@ -74,7 +74,7 @@ research.base_energistics.stage.1=作为一名科学家兼神秘学者，我设�
 # Research Digisentia
 research.digisentia.title=源质数位化
 research.digisentia.stage.1=完成要素蒸馏的研究后，我突然想到，也许能将其数位化存储。<BR>测试§l成型核心§r和§l破坏核心§r时，我意识到只要稍加修改，它们就可以作为将源质与数字格式间相互转换的一种手段。<BR>由于某些源质天生具有腐蚀性，需要在电路表面覆上一层水银以防止腐蚀。
-research.digisentia.stage.2=§l扩散核心§r<BR>液态源质具有相对较高的波动性和巨大的能量，这使得需先将其扩散稀释，然后再数位化。这时候就需要某种缓冲器来容纳这些扩散的源质。<PAGE><LINE>§l聚集核心§r<BR>压缩并将分散的源质重塑凝为原先的液态。很可能也需要这样一个缓冲器。
+research.digisentia.stage.2=§l扩散核心§r<BR>液态源质具有相对较高的挥发性和巨大的能量，这使得需先将其扩散稀释，然后再数位化。这时候就需要某种缓冲器来容纳这些扩散的源质。<PAGE><LINE>§l聚集核心§r<BR>压缩并将分散的源质重塑凝为原先的液态。很可能也需要这样一个缓冲器。
 
 # Research Digisentia Storage
 # 1k

--- a/projects/1.12.2/assets/thaumic-energistics/thaumicenergistics/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/thaumic-energistics/thaumicenergistics/lang/zh_cn.lang
@@ -1,62 +1,116 @@
-gui.thaumicenergistics.arcane_terminal=奥术终端
-gui.thaumicenergistics.essentia_export_bus=ME源质输出总线
-gui.thaumicenergistics.essentia_import_bus=ME源质输入总线
-gui.thaumicenergistics.essentia_storage_bus=ME源质存储总线
-gui.thaumicenergistics.essentia_terminal=源质终端
-gui.thaumicenergistics.vis_available=%s可使用
-gui.thaumicenergistics.vis_discount=%s%%折扣
-gui.thaumicenergistics.vis_required=Vis：%s
-item.thaumicenergistics.arcane_terminal.name=奥术合成终端
-item.thaumicenergistics.coalescence_core.name=聚集核心
+﻿# Creative Tab
+itemGroup.ThaumicEnergistics=神秘能源
+
+# Blocks
+tile.thaumicenergistics.infusion_provider.name=注魔供应器
+
+# Items
 item.thaumicenergistics.diffusion_core.name=扩散核心
-item.thaumicenergistics.essentia_cell_16k.name=16k-ME源质存储元件
-item.thaumicenergistics.essentia_cell_1k.name=1k-ME源质存储元件
-item.thaumicenergistics.essentia_cell_4k.name=4k-ME源质存储元件
-item.thaumicenergistics.essentia_cell_64k.name=64k-ME源质存储元件
-item.thaumicenergistics.essentia_cell_creative.name=创造型ME源质存储元件
-item.thaumicenergistics.essentia_component_16k.name=16k-ME源质存储组件
+item.thaumicenergistics.coalescence_core.name=聚集核心
+
 item.thaumicenergistics.essentia_component_1k.name=1k-ME源质存储组件
 item.thaumicenergistics.essentia_component_4k.name=4k-ME源质存储组件
+item.thaumicenergistics.essentia_component_16k.name=16k-ME源质存储组件
 item.thaumicenergistics.essentia_component_64k.name=64k-ME源质存储组件
-item.thaumicenergistics.essentia_export.name=ME源质输出总线
+
+item.thaumicenergistics.essentia_cell_1k.name=1k-ME源质存储元件
+item.thaumicenergistics.essentia_cell_4k.name=4k-ME源质存储元件
+item.thaumicenergistics.essentia_cell_16k.name=16k-ME源质存储元件
+item.thaumicenergistics.essentia_cell_64k.name=64k-ME源质存储元件
+item.thaumicenergistics.essentia_cell_creative.name=创造型ME源质存储元件
+
 item.thaumicenergistics.essentia_import.name=ME源质输入总线
+item.thaumicenergistics.essentia_export.name=ME源质输出总线
 item.thaumicenergistics.essentia_storage.name=ME源质存储总线
 item.thaumicenergistics.essentia_terminal.name=ME源质终端
+item.thaumicenergistics.arcane_terminal.name=奥术合成终端
+
 item.thaumicenergistics.upgrade_arcane.name=奥术充能升级
-itemGroup.ThaumicEnergistics=神秘能源
-research.arcaneterminal.addena.1=我可以升级我的奥术合成终端以增加其 vis 抽取范围
-research.arcaneterminal.stage.1=也许我可以将一个ME终端和奥术工作台结合起来，以获得一些能帮助我完成奥术工作的东西
-research.arcaneterminal.stage.2=我现在可以制作奥术合成终端
-research.arcaneterminal.title=奥术合成终端
-research.base_energistics.stage.1=作为一名科学家和神秘学者，我假设必须能够以稳定和富有成效的方式将科技与魔法结合起来。<BR>我应该详细研究物质和能量转换的原理来实现。很可能神秘学的某些方面可以实现，以及能够做到这一点的科技。<BR>这需要进行广泛的研究，但我相信这将是我值得投入的时间。
-research.base_energistics.title=神秘能源
-research.digisentia.stage.1=在发现了如何提炼源质之后，我发现我可能能够以数码的方式存储它。<BR>检查§l成型核心§r和§l破坏核心§r时，我意识到通过一些微小的修改，它们可以作为将源质转换为数码格式和从数码格式转换回来的方法。<BR>然而，由于某些类型的必需品的腐蚀性，需要在电路周围设置一层水银，以防止衰变。
-research.digisentia.stage.2=§l扩散核心§r<BR>蒸馏源质中相对较高的挥发性和巨大的能量要求它首先被扩散然后再数码化。可能需要某种缓冲室来保持扩散的本质。<PAGE><LINE>§l聚集核心§r<BR>压缩并将重新物化的源质扩散回到原始的形式。也可能需要缓冲室。
-research.digisentia.title=源质数位化
-research.essentiabuses.stage.1=现在我可以将源质数码化了，是时候将这项技术付诸实践了
-research.essentiabuses.stage.2=我现在可以制作源质总线
-research.essentiabuses.title=数码源质传输
-research.essentiastorage16k.stage.1=就像我之前尝试获得更大的存储组件一样，我可以使用一些高端处理器将多个存储组件组合在一起
-research.essentiastorage16k.stage.2=使用其他类型的处理单元，我现在可以存储16倍原始存储系统的源质数量于存储组件中
-research.essentiastorage16k.title=更大的数码源质存储
-research.essentiastorage1k.stage.1=在检查现有的数码存储介质时，我得出的结论是，我实际上可以存储数码化的源质。<BR>通过将§l赛特斯石英§r与§l世界盐§r一起使用，它应该能够存储源质，即使在数码形式下它仍然非常活跃。<BR>我认为§l世界盐§r的浓度越高，它应该能够存储得越多，尽管石英本身可以储存的数量有继承限制。
-research.essentiastorage1k.stage.2=我设法创建了一个能够以数码方式存储少量源质的存储设备，也许我可以组合多个组件以增加存储空间？
-research.essentiastorage1k.title=数码源质存储
-research.essentiastorage4k.stage.1=也许我可以使用一些不同的处理组件将多个存储组件组合在一起
-research.essentiastorage4k.stage.2=我现在可以通过使用一些计算处理单元以数码方式存储相当数量的源质，以允许组件相互通信
-research.essentiastorage4k.title=大数码源质存储
-research.essentiastorage64k.stage.1=我目前的存储需求是不够的，我希望我仍然可以将存储组件组合起来创建一个更大的存储组件，同时占用相同的空间……
-research.essentiastorage64k.stage.2=我现在可以在存储组件上存储大量的源质，但我觉得这是技术的极限
-research.essentiastorage64k.title=海量数码源质存储
-research.essentiaterminal.stage.1=现在我可以将源质数码化了，是时候将这项技术付诸实践了
-research.essentiaterminal.stage.2=我现在可以制作源质终端
-research.essentiaterminal.title=源质终端
-research.infusionprovider.stage.1=现在我可以将源质数码化了，是时候将这项技术付诸实践了
-research.infusionprovider.stage.2=我现在可以制作注魔供应器
-research.infusionprovider.title=注魔供应器
-tc.research_category.THAUMICENERGISTICS=神秘能源
-tile.thaumicenergistics.infusion_provider.name=源质供应器
+
+# Tooltips
 tooltip.thaumicenergistics.wip=未完成，请勿使用
-card.tinkerae.name=修复物质/能量
-card.tinkerae.text=尝试将源质转化为与当前物质/能量网络类似的能量。获得10-25能量。
-research.arcaneterminal.addenda.1=我可以升级我的奥术合成终端来增加它的 vis 接收范围
+
+# GUI
+gui.thaumicenergistics.essentia_import_bus=ME源质输入总线
+gui.thaumicenergistics.essentia_export_bus=ME源质输出总线
+gui.thaumicenergistics.essentia_storage_bus=ME源质存储总线
+gui.thaumicenergistics.essentia_terminal=ME源质终端
+gui.thaumicenergistics.arcane_terminal=奥术合成终端
+
+gui.thaumicenergistics.vis_required=Vis消耗：%s
+gui.thaumicenergistics.vis_available=%s 可用
+gui.thaumicenergistics.vis_discount=%s%% 减免
+
+card.tinkerae.name=捣鼓ME网络
+card.tinkerae.text=尝试将源质转化为能量，就像你的ME网络一样。获得10到25点 能源学 进度。
+
+# FROM THAUMCRAFT en_US.lang
+# BEST TO RECHECK THE LATEST LANG FILE FOR CHANGED FORMATTING
+#
+# Special formatting codes:
+# <BR> or <BR/>         Paragraph break (<BR/> is included for people using XML for their localization)
+# <LINE> or <LINE/>     Insert a fancy centered linebreak between sections of text.
+# <DIV> or <DIV/>     Insert a fancy left-justified linebreak between sections of text.
+# <PAGE> or <PAGE/>     Skip to a new page.
+# <IMG>...</IMG>  Insert a centered image into text. Parameters are separated by ':' and are:
+#                    - mod resource location name
+#                    - png file location (assumed to be a 256x256 texture, a sub-image will be grabbed from this png as specified below)
+#                    - x location of sub-image in png
+#                    - y location of sub-image in png
+#                    - x size of sub-image (255 if full x size of png must be used)
+#                    - y size of sub-image (255 if full y size of png must be used)
+#                    - scaling - 1.0 for normal 256x256 images, or smaller for proportionately smaller .png files (a 16x16 image will be 0.0625)
+#               Examples:
+#                   <IMG>thaumcraft:textures/gui/gui_researchbook.png:24:184:96:4:1.0</IMG>   <-- line break image as used in <LINE> above
+#                   <IMG>thaumcraft:textures/items/alumentum.png:0:0:255:255:0.0625</IMG>     <-- alumentum item icon
+
+# Research Category
+tc.research_category.THAUMICENERGISTICS=能源学
+
+# Research Basics
+research.base_energistics.title=神秘能源
+research.base_energistics.stage.1=作为一名科学家兼神秘学者，我设想有方法将科技与魔法稳定且有效地结合起来。<BR>我应该仔细研究物质和能量互相转换的原理来实现它。似乎神秘学中有要素可以做到，科技中也有方法做到同样的事。<BR>这需要进行大量的研究，但我相信这样投入时间是值得的。
+
+# Research Digisentia
+research.digisentia.title=源质数位化
+research.digisentia.stage.1=完成要素蒸馏的研究后，我突然想到，也许能将其数位化存储。<BR>测试§l成型核心§r和§l破坏核心§r时，我意识到只要稍加修改，它们就可以作为将源质与数字格式间相互转换的一种手段。<BR>由于某些源质天生具有腐蚀性，需要在电路表面覆上一层水银以防止腐蚀。
+research.digisentia.stage.2=§l扩散核心§r<BR>液态源质具有相对较高的波动性和巨大的能量，这使得需先将其扩散稀释，然后再数位化。这时候就需要某种缓冲器来容纳这些扩散的源质。<PAGE><LINE>§l聚集核心§r<BR>压缩并将分散的源质重塑凝为原先的液态。很可能也需要这样一个缓冲器。
+
+# Research Digisentia Storage
+# 1k
+research.essentiastorage1k.title=数位化源质存储
+research.essentiastorage1k.stage.1=在检查了现有的数位化存储介质后，我得出结论，我实际上可以存储数位化的源质。<BR>§l赛特斯石英§r通过注入§l世界盐§r，就应该会获得存储源质的能力，在数位化的格式下也十分有效。<BR>我认为注入的§l世界盐§r的浓度越高，它能储存的东西应该就越多，尽管这一数值还会受到石英本身的限制。
+research.essentiastorage1k.stage.2=我已经成功地制造出了一个能够数位化存储少量源质的存储元件，也许可以组合多个组件以增加存储空间？
+# 4k
+research.essentiastorage4k.title=加大数位化源质存储
+research.essentiastorage4k.stage.1=也许我可以使用一些不同的处理器，将多个存储组件组合在一起。
+research.essentiastorage4k.stage.2=通过使用一些运算处理器，让各个组件之间能够相互通信，我现在可以数位化存储相当数量的源质。
+# 16k
+research.essentiastorage16k.title=大量数位化源质存储
+research.essentiastorage16k.stage.1=就像之前试图获得更大的存储组件一样，我可以使用一些高端处理器将多个存储组件组合在一起。
+research.essentiastorage16k.stage.2=通过使用另一种处理器，我现在可以存储刚开始使用简陋存储网络时16倍的源质数量于一个存储组件中。
+# 64k
+research.essentiastorage64k.title=海量数位化源质存储
+research.essentiastorage64k.stage.1=我目前的存储需求还未被满足。希望我仍能将存储组件组合起来，在占用相同空间的情况下创造一个更大的存储组件……
+research.essentiastorage64k.stage.2=我现在可以在存储组件上存储大量的源质，但我觉得这已经是这项技术的极限了。
+
+# Research Essentia Buses
+research.essentiabuses.title=数位化源质传输
+research.essentiabuses.stage.1=我现在已经拥有了用ME网络安全运输源质的存储组件，可以着手于创造源质总线了。
+research.essentiabuses.stage.2=我现在可以合成源质输入、输出和存储总线了。它们的功能与物品总线完全相同。
+
+# Research Essentia Terminal
+research.essentiaterminal.title=源质监控
+research.essentiaterminal.stage.1=虽然我现在可以将源质数位化，但我意识到这意味着我无法再观察到已经数位化的源质的数量了——这是个紧迫的问题。
+research.essentiaterminal.stage.2=通过ME源质终端，我可以看到ME网络可访问的所有源质。此外，我还可以通过它用玻璃安瓿存入和取出要素。
+
+# Research Infusion Provider
+research.infusionprovider.title=注魔供应器
+research.infusionprovider.stage.1=虽然能够用我的ME网络操纵源质已非常宝贵，但我对注魔所需的过程感到失望——我必须现场将所有要素提取到源质罐子里。如果能把我的源质供应给符文矩阵，就像源质终端一样的话……
+research.infusionprovider.stage.2=大功告成！注魔供应器可将整个ME网络的源质供应给注魔进程！此外，它还能与我的ME源质存储总线配合使用，让我可以创建源质子网络，以备不时之需。
+
+# Research Arcane Crafting Terminal
+research.arcaneterminal.title=奥术合成终端
+research.arcaneterminal.stage.1=每次合成，我都不得不在我的ME网络和奥术工作台之间跳来跳去，真令人丧气。虽然它比单纯的合成终端复杂得多，但我应该可以用相同的原理将我的奥术工作台连接到ME网络上。
+research.arcaneterminal.stage.2=奥术合成终端可以让我的奥术工作台充分利用我的ME网络。
+research.arcaneterminal.addenda.1=我可以用奥术充能升级来升级我的奥术合成终端，以允许它从所有邻近的区块中抽取Vis。


### PR DESCRIPTION
[#2453](https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/pull/2453#)
https://www.curseforge.com/minecraft/mc-mods/thaumic-energistics-extended-life
换个比较库，之前那个很久之前交的，当时还不会用Github，而且这个修改版也没有登录curseforge