### PR TITLE
IndustrialCraft2 翻译更新

### DIFF
--- a/projects/1.12.2/assets/ic2-classic/ic2/lang_ic2/zh_cn.properties
+++ b/projects/1.12.2/assets/ic2-classic/ic2/lang_ic2/zh_cn.properties
@@ -10,12 +10,12 @@ cable.gold_cable_1=绝缘金质导线
 cable.gold_cable_2=2x绝缘金质导线
 cable.iron_cable_0=高压导线
 cable.iron_cable_1=绝缘高压导线
-cable.iron_cable_2=2x绝缘高压导线
-cable.iron_cable_3=3x绝缘高压导线
+cable.iron_cable_2=2x 绝缘高压导线
+cable.iron_cable_3=3x 绝缘高压导线
 cable.tin_cable_0=锡质导线
 cable.tin_cable_1=绝缘锡质导线
-cable.detector_cable=EU检测导线
-cable.splitter_cable=EU分流导线
+cable.detector_cable=EU 检测导线
+cable.splitter_cable=EU 分流导线
 cable.tooltip.loss=损耗：%s EU/方块
 
 #Pipes
@@ -74,7 +74,7 @@ resource.reactor_vessel=核反应堆压力容器
 misc_resource.ashes=灰烬
 misc_resource.iridium_ore=铱矿石
 misc_resource.iridium_shard=铱碎片
-misc_resource.matter=UU物质
+misc_resource.matter=UU 物质
 misc_resource.resin=粘性树脂
 misc_resource.slag=炉渣
 misc_resource.iodine=碘
@@ -166,10 +166,15 @@ dust.bronze=青铜粉
 dust.clay=粘土粉
 dust.silver=银粉
 dust.netherrack=地狱岩粉
-
+dust.ender_pearl=末影珍珠粉
+dust.ender_eye=末影之眼粉
+dust.milk=奶粉
+dust.emerald=绿宝石粉
 
 #Small Dusts
 dust.small_copper=小撮铜粉
+dust.small_diamond=小撮钻石粉
+dust.small_emerald=小撮绿宝石粉
 dust.small_gold=小撮金粉
 dust.small_tin=小撮锡粉
 dust.small_silver=小撮银粉
@@ -187,7 +192,7 @@ fluid_cell=通用流体单元
 cell.empty=空单元
 cell.lava=熔岩单元
 cell.water=水单元
-itemCellUuMatter=UU物质单元
+itemCellUuMatter=UU 物质单元
 itemCellCF=建筑泡沫单元
 cell.air=压缩空气单元
 cell.hydrated_coal=压缩煤单元
@@ -195,8 +200,8 @@ itemCellBiomass=生物质单元
 cell.coalfuel=煤油单元
 itemCellBiogas=沼气单元
 cell.electrolyzed_water=电解水单元
-itemCellCoolant=IC2冷却液单元
-itemCellHotCoolant=IC2热冷却液单元
+itemCellCoolant=工业时代 2 冷却液单元
+itemCellHotCoolant=工业时代 2 热冷却液单元
 itemCellPahoehoelava=绳状熔岩单元
 itemCellSteam=蒸汽单元
 cell.hydration=水化单元
@@ -211,8 +216,8 @@ drill=采矿钻头
 diamond_drill=钻石钻头
 iridium_drill=铱钻头
 chainsaw=链锯
-scanner=OD扫描器
-advanced_scanner=OV扫描器
+scanner=OD 扫描器
+advanced_scanner=OV 扫描器
 scanner.range=范围：%s
 itemScanner.found=扫描结果：
 wrench=扳手
@@ -269,7 +274,7 @@ painter.red=红色刷子
 painter.white=白色刷子
 painter.yellow=黄色刷子
 
-meter=EU电表
+meter=EU 电表
 itemToolMEter.mode=模式：
 itemToolMEter.mode.EnergyIn=能量流入
 itemToolMEter.mode.EnergyOut=能量流出
@@ -281,8 +286,8 @@ itemToolMEter.cycle=周期：%1$s 秒
 itemToolMEter.avg=平均：
 itemToolMEter.max/min=最大/最小
 
-upgrade_kit.mfsu=MFSU升级组件
-upgrade_kit.mfsu.info=可以升级MFE和MFE充电座
+upgrade_kit.mfsu=MFSU 升级组件
+upgrade_kit.mfsu.info=可以升级 MFE 储电箱和 MFE 充电座
 
 
 #Armour and Stuff
@@ -329,6 +334,7 @@ upgrade.advanced_pulling=高级抽入升级
 upgrade.fluid_ejector=流体弹出升级
 upgrade.fluid_pulling=流体抽入升级
 upgrade.redstone_inverter=红石信号反转升级
+upgrade.remote_interface=远程接口升级
 upgrade.advancedGUI.meta=元数据
 upgrade.advancedGUI.damage=损耗值
 upgrade.advancedGUI.nbt=NBT
@@ -357,14 +363,14 @@ upgrade.advancedGUI.exact.desc=所有 NBT 均被检查
 ## REACTORS ##
 #Reactor Stuff - Tooltips
 reactoritem.heatwarning.line1=无法在流体冷却模式下使用
-reactoritem.heatwarning.line2=请在EU模式下使用
+reactoritem.heatwarning.line2=请在 EU 模式下使用
 reactoritem.durability=耐久：
 
 
 #Reactor Stuff - Cooling/Heat Management
-heat_storage=10k冷却单元
-tri_heat_storage=30k冷却单元
-hex_heat_storage=60k冷却单元
+heat_storage=10k 冷却单元
+tri_heat_storage=30k 冷却单元
+hex_heat_storage=60k 冷却单元
 plating=反应堆隔板
 heat_plating=高热容反应堆隔板
 containment_plating=密封反应堆隔热板
@@ -474,6 +480,21 @@ crop.acacia_sapling=金合欢
 crop.dark_oak_sapling=深色橡树
 crop.birch_sapling=白桦
 crop.jungle_sapling=丛林
+crop.blazereed=烈焰甘蔗
+crop.bobs_yer_uncle_ranks_berries=鲍勃叔叔绿宝石浆果
+crop.corium=皮革花
+crop.corpse_plant=血骨花
+crop.creeper_weed=爬行者杂草
+crop.diareed=钻石甘蔗
+crop.egg_plant=鸡蛋花
+crop.ender_blossom=末影花苞
+crop.meat_rose=肉玫瑰
+crop.milk_wart=牛奶疣
+crop.oil_berries=原油浆果
+crop.slime_plant=粘液灌木丛
+crop.spidernip=蛛网藤
+crop.tearstalks=垂泪藤
+crop.withereed=煤炭甘蔗
 
 
 #Batteries
@@ -525,8 +546,11 @@ boat.rubber=橡皮艇
 boat.broken_rubber=损坏的橡皮艇
 boat.electric=电动艇
 terra_wart=大地疣
+crop_res.bobs_yer_uncle_ranks_berry=鲍勃叔叔绿宝石浆果
 crop_res.coffee_beans=咖啡豆
 crop_res.coffee_powder=咖啡粉
+crop_res.milk_wart=牛奶疣
+crop_res.oil_berry=原油浆果
 mug.empty=石杯
 mug.cold_coffee=冷咖啡
 mug.dark_coffee=黑咖啡
@@ -555,11 +579,11 @@ containment_box=防辐射容纳盒
 
 #Fluids
 pahoehoe_lava=绳状熔岩
-uu_matter=UU物质
+uu_matter=UU 物质
 construction_foam=建筑泡沫
-coolant=IC2冷却液
+coolant=工业时代 2 冷却液
 creosote=杂酚油
-hot_coolant=IC2热冷却液
+hot_coolant=工业时代 2 热冷却液
 biogas=沼气
 biomass=生物质
 distilled_water=蒸馏水
@@ -571,6 +595,7 @@ heavy_water=重水
 hydrogen=氢气
 oxygen=氧气
 weed_ex=除草剂喷雾
+milk=牛奶
 
 
 #Machine
@@ -708,7 +733,7 @@ Condenser.gui.tooltipvent=放置散热片来加速进程（%1$s EU/个）
 
 te.steam_generator=蒸汽机
 SteamGenerator.gui.name=蒸汽机
-SteamGenerator.gui.heatInput=输入：%1$s Hu/t
+SteamGenerator.gui.heatInput=输入：%1$s HU/t
 SteamGenerator.gui.pressurevalve=%1$s Bar
 SteamGenerator.gui.systemheat=系统热量：%1$s C
 SteamGenerator.output.water=水
@@ -723,7 +748,7 @@ SteamGenerator.gui.info.fluidoutput=输出：
 
 te.blast_furnace=高炉
 BlastFurnace.gui.name=高炉
-BlastFurnace.gui.toolair=每次运行需要6个压缩空气单元
+BlastFurnace.gui.toolair=每次运行需要 6 个压缩空气单元
 BlastFurnace.gui.airmiss=需要更多的压缩空气单元
 BlastFurnace.gui.progress=进度：
 BlastFurnace.gui.heat=热量：
@@ -785,7 +810,7 @@ IndustrialWorkbench.gui.adjacent=附近的机器
 
 te.batch_crafter=批量工作台
 
-te.uu_assembly_bench=UU组装台
+te.uu_assembly_bench=UU 组装台
 
 
 #Transformers
@@ -806,9 +831,9 @@ Transformer.gui.refresh=只在电网中没有电时才需要手动强制刷新
 
 #EU Storage
 te.batbox=储电箱
-te.cesu=CESU储电箱
-te.mfe=MFE储电箱
-te.mfsu=MFSU储电箱
+te.cesu=CESU 储电箱
+te.mfe=MFE 储电箱
+te.mfsu=MFSU 储电箱
 
 te.chargepad_batbox=充电座（储电盒）
 te.chargepad_cesu=充电座（CESU）
@@ -843,8 +868,8 @@ NuclearReactor.gui.name=核反应堆
 NuclearReactor.gui.info.EUoutput=输出：%1$s EU/t
 NuclearReactor.gui.info.HUoutput=输出：%1$s HU/s
 NuclearReactor.gui.info.temp=堆温：%1$.2f%%
-NuclearReactor.gui.mode.fluid=核反应堆处于流体冷却模式：输出100%
-NuclearReactor.gui.mode.electric=核反应堆处于EU模式：输出50%
+NuclearReactor.gui.mode.fluid=核反应堆处于流体冷却模式：输出 100%
+NuclearReactor.gui.mode.electric=核反应堆处于 EU 模式：输出 50%
 
 te.rci_rsh=反应堆冷却液注入器（RSH）
 te.rci_lzh=反应堆冷却液注入器（LZH）
@@ -860,7 +885,7 @@ SolarGenerator.gui.name=太阳能板
 
 te.stirling_generator=斯特林发电机
 StirlingGenerator.gui.name=斯特林发电机
-StirlingGenerator.gui.productiontooltip=目前收到的热量/目前输出的EU
+StirlingGenerator.gui.productiontooltip=目前收到的热量/目前输出的 EU
 
 te.water_generator=水力发电机
 WaterGenerator.gui.name=水力发电机
@@ -891,7 +916,7 @@ SolidHeatGenerator.gui.tooltipheat=目前发热/最大发热
 te.electric_heat_generator=电力加热机
 ElectricHeatGenerator.gui.name=电力加热机
 ElectricHeatGenerator.gui.tooltipheat=目前发热/最大发热
-ElectricHeatGenerator.gui.hUmax=%1$s hU/最大 %2$s hU
+ElectricHeatGenerator.gui.hUmax=%1$s HU/最大 %2$s HU
 ElectricHeatGenerator.gui.coils=放置线圈来增加输出热量
 
 
@@ -933,11 +958,11 @@ SteamKineticGenerator.gui.error.noturbine=错误：没有蒸汽涡轮
 SteamKineticGenerator.gui.error.filledupwithwater=错误：蒸汽涡轮被水阻挡
 SteamKineticGenerator.gui.aktive=蒸汽动能发生机：运行中……
 SteamKineticGenerator.gui.waiting=蒸汽动能发生机：等待中……
-SteamKineticGenerator.gui.turbine.ouput=输出：%1$skU
+SteamKineticGenerator.gui.turbine.ouput=输出：%1$s kU
 
 te.electric_kinetic_generator=电力动能发生机
 ElectricKineticGenerator.gui.name=电力动能发生机
-ElectricKineticGenerator.gui.tooltipkin=当前kU / 最大kU
+ElectricKineticGenerator.gui.tooltipkin=当前 kU / 最大 kU
 ElectricKineticGenerator.gui.kUmax=%1$s kU / 最大 %2$s kU
 ElectricKineticGenerator.gui.motors=添加马达来增加动能输出
 
@@ -985,6 +1010,7 @@ te.luminator_flat=日光灯
 te.personal_chest=保险箱
 te.trade_o_mat=贸易箱
 te.energy_o_mat=能源交易机
+te.trading_terminal=贸易终端机
 
 te.teleporter=传送机
 te.tesla_coil=特斯拉线圈
@@ -1053,27 +1079,27 @@ achievement.buildDDrill.desc=把你的钻头升级成钻石钻头
 achievement.buildIDrill=非常有价值的升级
 achievement.buildIDrill.desc=把你的钻石钻头升级成铱钻头
 achievement.buildMFE=升级储电设备
-achievement.buildMFE.desc=建造一个MFEU
+achievement.buildMFE.desc=建造一个 MFEU
 achievement.buildMiningLaser=镭射时间到
 achievement.buildMiningLaser.desc=制作一把采矿镭射枪
-achievement.killDragonMiningLaser=像Boss一样
+achievement.killDragonMiningLaser=像 Boss 一样
 achievement.killDragonMiningLaser.desc=用采矿镭射枪杀死末影龙
 achievement.buildMassFab=将能量转换为物质
 achievement.buildMassFab.desc=建造一台物质合成机
 achievement.acquireMatter=粉红色粘球
-achievement.acquireMatter.desc=制造出UU物质
+achievement.acquireMatter.desc=制造出 UU 物质
 achievement.replicateObject=似曾相识
-achievement.replicateObject.desc=用UU物质和复制机复制一些东西
+achievement.replicateObject.desc=用 UU 物质和复制机复制一些东西
 achievement.buildQArmor=高科技奇迹
 achievement.buildQArmor.desc=制作出量子套装中的一件
 achievement.starveWithQHelmet=忘记充电
 achievement.starveWithQHelmet.desc=戴着量子头盔淹死或饿死
 achievement.buildMFS=实在太多了
-achievement.buildMFS.desc=建造一个MFSU
+achievement.buildMFS.desc=建造一个 MFSU
 achievement.buildTeleporter=空间扭曲技术
 achievement.buildTeleporter.desc=建造传送机
 achievement.teleportFarAway=很远很远的地方
-achievement.teleportFarAway.desc=传送至少1km
+achievement.teleportFarAway.desc=传送至少 1 千米
 achievement.buildTerraformer=改变世界
 achievement.buildTerraformer.desc=建造地形转换机
 achievement.terraformEndCultivation=末地如天堂
@@ -1094,12 +1120,12 @@ container.personalTrader.offer=提供：
 container.personalTrader.totalTrades0=已执行
 container.personalTrader.totalTrades1=交易：
 container.personalTrader.stock=库存：
-container.personalTraderEnergy.paidFor=为%1$s EU付款
+container.personalTraderEnergy.paidFor=为%1$s EU 付款
 container.personalTraderEnergy.energyBuffer=缓存：
 
 
 # creative tab
-itemGroup.IC2=工业时代2
+itemGroup.IC2=工业时代 2
 
 
 # potion effects
@@ -1114,14 +1140,15 @@ death.attack.radiation=%1$s因辐射阵亡
 
 
 # tool tips
-tooltip.upgrade.overclocker.time=加工用时缩短为%1$s%%
-tooltip.upgrade.overclocker.power=能量增加到%1$s%%
+tooltip.upgrade.overclocker.time=加工用时缩短为 %1$s%%
+tooltip.upgrade.overclocker.power=能量增加到 %1$s%%
 tooltip.upgrade.transformer=增加 %1$s 级输出电压
 tooltip.upgrade.storage=增加 %1$s EU 储能
-tooltip.upgrade.ejector=向%1$s自动输出
+tooltip.upgrade.ejector=向 %1$s 自动输出
 tooltip.upgrade.ejector.anyside=第一格有效
 tooltip.upgrade.redstone=反转当前的红石信号
-tooltip.upgrade.pulling=自动从%1$s抽入物品
+tooltip.upgrade.pulling=自动从 %1$s 抽入物品
+tooltip.upgrade.remote_interface=远程范围扩展至 2^%1$s
 tooltip.mode=模式：%1$s
 tooltip.mode.enabled=启用
 tooltip.mode.disabled=禁用
@@ -1144,7 +1171,7 @@ tooltip.mode.noShear=不剪叶子模式
 
 #mouse over tool tips
 item.CrystalMemory.tooltip.Item=物品：
-item.CrystalMemory.tooltip.UU-Matter=UU物质：
+item.CrystalMemory.tooltip.UU-Matter=UU 物质：
 item.CrystalMemory.tooltip.Energy=电量：
 item.CrystalMemory.tooltip.Empty=<空>
 item.tooltip.power=需要电量
@@ -1174,7 +1201,7 @@ jei.recipes=显示配方
 
 #Generic
 generic.text.upgrade=兼容的升级插件：
-generic.text.UUMatte=UU物质：
+generic.text.UUMatte=UU 物质：
 generic.text.Energy=电量：
 generic.text.Name=名称：
 generic.text.EU=EU
@@ -1185,7 +1212,7 @@ generic.text.bucketUnit=B
 generic.text.empty=空
 generic.text.heat=热量：
 generic.text.Buffer=缓冲：
-generic.text.hu=Hu：
+generic.text.hu=HU：
 generic.text.bufferEU=暂存：%1$s EU
 generic.text.C=%1$s C
 generic.text.bar=%1$s bar
@@ -1210,24 +1237,24 @@ dir.West=西部
 
 #Config GUI
 config.sub.worldgen=世界生成
-config.sub.worldgen.tooltip=配置 IC2 自然生成。
+config.sub.worldgen.tooltip=配置工业时代 2 自然生成。
 config.worldgen.rubberTree.tooltip=启用橡胶树自然生成。
 config.worldgen.copperOre.tooltip=启用铜矿自然生成。
 config.worldgen.tinOre.tooltip=启用锡矿自然生成。
 config.worldgen.uraniumOre.tooltip=启用铀矿自然生成。
 config.worldgen.leadOre.tooltip=启用铅矿自然生成。
-config.worldgen.oreDensityFactor.tooltip=IC2 矿物生成比例
+config.worldgen.oreDensityFactor.tooltip=工业时代 2 矿物生成比例
 config.worldgen.treeDensityFactor.tooltip=橡胶树生成比例
-config.worldgen.retrogenCheckLimit.tooltip=每tick最多检查拥有自然生成的区块数量。\n设置为0时不检查
-config.worldgen.retrogenUpdateLimit.tooltip=每 tick 重新生成区块的最大值。\n超过 retrogenCheckLimit 的数值会被截断。
+config.worldgen.retrogenCheckLimit.tooltip=每刻最多检查拥有自然生成的区块数量。\n设置为0时不检查
+config.worldgen.retrogenUpdateLimit.tooltip=每刻重新生成区块的最大值。\n超过每刻最多检查拥有自然生成的区块数量的数值会被截断。
 config.sub.protection=保护
 config.sub.protection.tooltip=配置爆炸功率限制，记录扳手动作和禁用核弹
 config.protection.wrenchLogging.tooltip=在使用扳手拆卸机器时启用玩家记录。
-config.protection.nukeExplosionPowerLimit.tooltip=核弹的最大爆炸威力，其中TNT为4。
-config.protection.reactorExplosionPowerLimit.tooltip=核电站的最大爆炸威力，其中TNT为4。
+config.protection.nukeExplosionPowerLimit.tooltip=核弹的最大爆炸威力，其中 TNT 为 4 。
+config.protection.reactorExplosionPowerLimit.tooltip=核电站的最大爆炸威力，其中 TNT 为 4 。
 config.protection.enableNuke.tooltip=启用核弹
 config.sub.balance=平衡
-config.sub.balance.tooltip=IC2 平衡设定
+config.sub.balance.tooltip=工业时代 2 平衡设定
 config.sub.energy=能量
 config.sub.energy.tooltip=机器平衡设定
 config.sub.generator=EU 发电机
@@ -1257,7 +1284,7 @@ config.balance.energy.heatgenerator.solid.tooltip=固体加热机输出
 config.balance.energy.heatgenerator.radioisotope.tooltip=放射性同位素加热机输出
 config.balance.energy.heatgenerator.electric.tooltip=电力加热机输出
 config.sub.kineticgenerator=动能发电机
-config.sub.kineticgenerator.tooltip=配置 KU 发电机的输出。\n增加以提高产量。
+config.sub.kineticgenerator.tooltip=配置 kU 发电机的输出。\n增加以提高产量。
 config.balance.energy.kineticgenerator.water.tooltip=水力动能发生机输出
 config.balance.energy.kineticgenerator.wind.tooltip=风力动能发生机输出
 config.balance.energy.kineticgenerator.manual.tooltip=手摇动能发生机输出
@@ -1281,8 +1308,8 @@ config.sub.calcification.tooltip=配置蒸汽机在失效前可以达到的最�
 config.balance.steamgenerator.calcification.maxcalcification.tooltip=最大钙化值
 config.sub.steamRepressurizer=蒸汽再加压机
 config.sub.steamRepressurizer.tooltip=关于蒸汽再加压机的配置
-config.balance.steamRepressurizer.steamPerSteam.tooltip=每 10mB IC2 蒸汽的量（以 mB 为单位）
-config.balance.steamRepressurizer.steamPerSuperSteam.tooltip=每 10mB IC2 过热蒸汽的量（以 mB 为单位）
+config.balance.steamRepressurizer.steamPerSteam.tooltip=每 10mB 工业时代 2 蒸汽的量（以 mB 为单位）
+config.balance.steamRepressurizer.steamPerSuperSteam.tooltip=每 10mB 工业时代 2 过热蒸汽的量（以 mB 为单位）
 config.sub.fermenter=发酵机
 config.sub.fermenter.tooltip=关于发酵机的配置。
 config.balance.fermenter.need_amount_biomass_per_run.tooltip=每工作周期需求的沼气量
@@ -1291,9 +1318,9 @@ config.balance.fermenter.hU_per_run.tooltip=每工作周期需求的热量
 config.balance.fermenter.biomass_per_fertilizier.tooltip=每产出一个肥料所需的生物质进度
 
 config.sub.uu-values=UU物质配置
-config.sub.uu-values.tooltip=更改UU相关值
+config.sub.uu-values.tooltip=更改 UU 相关值
 config.sub.predefined=预设值
-config.sub.predefined.tooltip=修正了其它物品计算的UU值
+config.sub.predefined.tooltip=修正了其它物品计算的 UU 值
 
 config.balance.minerDischargeTier.tooltip=采矿机可以使用的电池最大能量等级。
 config.balance.teleporterUseInventoryWeight.tooltip=根据玩家通过传送机时的物品栏填充量增加能耗。
@@ -1307,18 +1334,18 @@ config.balance.recyclerWhitelist.tooltip=允许回收的方块/物品的白名�
 config.balance.ignoreWrenchRequirement.tooltip=允许使用镐而不需要扳手来拾取方块。
 config.balance.watermillAutomation.tooltip=允许对水力发电机的水槽进行自动化。
 config.sub.recipes=配方
-config.sub.recipes.tooltip=配置 IC2 的配方和其他配方相关的东西。
+config.sub.recipes.tooltip=配置工业时代 2 的配方和其他配方相关的东西。
 config.recipes.disable=禁用配方
-config.recipes.disable.tooltip=禁用具有指定输出的 IC2 制作配方。
+config.recipes.disable.tooltip=禁用具有指定输出的工业时代 2 制作配方。
 config.recipes.purge=移除配方
 config.recipes.purge.tooltip=移除指定的产物（包括原版与 Mod ）的配方。
-config.recipes.allowCoinCrafting.tooltip=启用 IC2 硬币的配方，否则它们只能自然生成而因此被限制。
-config.recipes.requireIc2Circuits.tooltip=只允许在 IC2 配方中使用 IC2 电路板。
-config.recipes.smeltToIc2Items.tooltip=调整冶炼配方以始终输出 IC2 物品（如果有）。
+config.recipes.allowCoinCrafting.tooltip=启用工业时代 2 硬币的配方，否则它们只能自然生成而因此被限制。
+config.recipes.requireIc2Circuits.tooltip=只允许在工业时代 2 配方中使用工业时代 2 电路板。
+config.recipes.smeltToIc2Items.tooltip=调整冶炼配方以始终输出工业时代 2 物品（如果有）。
 config.recipes.ignoreInvalidRecipes.tooltip=忽略无效配方。
 config.sub.misc=杂项
 config.sub.misc.tooltip=常规配置选项。
-config.misc.enableIc2Audio.tooltip=启用 IC2 自定义声音系统。
+config.misc.enableIc2Audio.tooltip=启用工业时代 2 自定义声音系统。
 config.misc.maxAudioSourceCount.tooltip=最大化激活的音频源的数量，只在你确切知道你在干什么的时候才可更改。
 config.misc.hideSecretRecipes.tooltip=启用隐藏合成。
 config.misc.quantumSpeedOnSprint.tooltip=在冲刺时启用量子护腿的速度提升，而不是按住加速键。


### PR DESCRIPTION
<!--
提交PR前请认真阅读下列文件：
贡献方针：https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md

你好！如果你是第一次提交 PR，请阅读下面的话：
请务必做好下面两件事情，一定一定不要提交了就不管了哦（这样会被拒收的哦）：
- 签署 CLA（贡献者许可协议；在 https://cla-assistant.io/CFPAOrg/Minecraft-Mod-Language-Package 签署）
- 等待审核者审核，并根据审核者的提示（邮件会发送）修改你提交的文件（修改方法可以参考 https://cfpa.cyan.cafe/Azusa/img/tip1.png ）
如果你访问 GitHub 较慢或根本无法访问，可以前往 https://cfpa.cyan.cafe/Azusa/GitHubInCNHelper 查看一些辅助访问的手段。
再次非常感谢你的提交。
-->

根据《Minecraft 模组简体中文翻译规范与指南》修正1.12.2版本工业时代的文本格式
添加了版本更新后缺失的物品翻译，大多数是关于作物杂交类的文本
[感谢MC百科的Player给出的作物文本翻译](https://bbs.mcmod.cn/thread-10404-1-1.html)
在他的文本基础上修改了两处翻译：“苦力怕”>“爬行者”、“油泉浆果”>“原油浆果”