### PR TITLE
停止支持 No Chat Reports 1.19

### DIFF
--- a/config/packer/1.19.json
+++ b/config/packer/1.19.json
@@ -5,7 +5,9 @@
             "zh_cn"
         ],
         "exclusionMods": [],
-        "exclusionNamespaces": []
+        "exclusionNamespaces": [
+            "nochatreports"
+        ]
     },
     "floating": {
         "inclusionDomains": [


### PR DESCRIPTION
来自 #4338 的相关更改要求
我比较了译文，认为上游库较本仓库更好，但仍有不足之处。
之后将交于 @IlyaYezelovsky 进行维护。

对上游仓库维护者：
No Chat Reports 的汉语语言文件仍有需要修改之处，如`option.NoChatReports.hideModifiedMessageIndicators.tooltip`缺少了颜色代码。其余错漏之处还请自行审查并修改，总体上这份译文语言较本仓库流畅且专业许多。
如因种种原因不再维护，也请重新提交议题，提示CFPA团队重新对其维护。

对争议与否：
上游仓库译文更好。
上游仓库维护者表示会长期维护。
先前的译者 @dovisutu 同意/希望交接。
故我认为没有争议，无需公示。