### PR TITLE
ae2guide 暂时停止支持

### DIFF
--- a/projects/1.20-fabric/assets/ex-pattern-provider/extendedae/local-config.json
+++ b/projects/1.20-fabric/assets/ex-pattern-provider/extendedae/local-config.json
@@ -1,5 +1,5 @@
 {
-    "inclusionDomains": ["ae2guide"],
+    "inclusionDomains": ["ae2guide-disable"],
     "exclusionDomains": [],
     "exclusionPaths": [],
     "inclusionPaths": [],

--- a/projects/1.20/assets/applied-energistics-2/ae2/local-config.json
+++ b/projects/1.20/assets/applied-energistics-2/ae2/local-config.json
@@ -1,5 +1,5 @@
 {
-    "inclusionDomains": ["ae2guide"],
+    "inclusionDomains": ["ae2guide-disable"],
     "exclusionDomains": [],
     "exclusionPaths": [],
     "inclusionPaths": [],

--- a/projects/1.20/assets/appliede/appliede/local-config.json
+++ b/projects/1.20/assets/appliede/appliede/local-config.json
@@ -1,5 +1,5 @@
 {
-    "inclusionDomains": ["ae2guide"],
+    "inclusionDomains": ["ae2guide-disable"],
     "exclusionDomains": [],
     "exclusionPaths": [],
     "inclusionPaths": [],

--- a/projects/1.20/assets/ex-pattern-provider/extendedae/local-config.json
+++ b/projects/1.20/assets/ex-pattern-provider/extendedae/local-config.json
@@ -1,5 +1,5 @@
 {
-    "inclusionDomains": ["ae2guide"],
+    "inclusionDomains": ["ae2guide-disable"],
     "exclusionDomains": [],
     "exclusionPaths": [],
     "inclusionPaths": [],


### PR DESCRIPTION
由于兼容性过差直接导致整个资源包读取错误，暂时排除。准备好后重新支持。