### PR TITLE
Scape and Run Parasites Addon: Cotesia Glomerata翻译更新

### DIFF
--- a/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/en_us.lang
+++ b/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/en_us.lang
@@ -16,6 +16,24 @@ potion.effect.recuperation=Potion of §dRecuperation
 lingering_potion.effect.recuperation=Lingering Potion of §dRecuperation
 tipped_arrow.effect.recuperation=Arrow of §dRecuperation
 
+effect.unkindling=§6Unkindling
+splash_potion.effect.unkindling=Splash Potion of §6Unkindling
+potion.effect.unkindling=Potion of §6Unkindling
+lingering_potion.effect.unkindling=Lingering Potion of §6Unkindling
+tipped_arrow.effect.unkindling=Arrow of §6Unkindling
+
+effect.yielding=§6Yielding
+splash_potion.effect.yielding=Splash Potion of §6Settling an Old Debt
+potion.effect.yielding=Potion of §6Settling an Old Debt
+lingering_potion.effect.yielding=Lingering Potion of §6Settling an Old Debt
+tipped_arrow.effect.yielding=Arrow of §6Settling an Old Debt
+
+effect.clotting=§4Clotting
+splash_potion.effect.clotting=Splash Potion of §4Blood Clotting
+potion.effect.clotting=Potion of §4Blood Clotting
+lingering_potion.effect.clotting=Lingering Potion of §4Blood Clotting
+tipped_arrow.effect.clotting=Arrow of §4Blood Clotting
+
 effect.dazed=Dazed
 splash_potion.effect.dazed=Splash Potion of Dazing
 potion.effect.dazed=Potion of Dazing
@@ -71,27 +89,75 @@ commands.srpcotesia.setbiomass.usage=/setbiomass <number> or /setbiomass <player
 commands.srpcotesia.setbloom.usage=/setbiomass <number> or /setbiomass <player(s)> <number>
 commands.srpcotesia.togglenote.usage=/togglenote or /togglenote <player(s)>
 commands.srpcotesia.setKillC.usage=/setbiomass <number> or /setbiomass <player(s)> <number>
-commands.srpcotesia.ante.usage=/ante <set|add|subtract> <ticks> or /ante query
+commands.srpcotesia.ante.usage=/ante <set|add|subtract|setminimum> <value> or /ante <query|recalibrate>
 commands.srpcotesia.atimer.usage=/atimer <set|add|subtract> <ticks> or /atimer query
 commands.srpcotesia.adapt.usage=/adapt <parasite(s)> <source>
+commands.srpcotesia.assimilateplayer.usage=/assimilateplayer <player(s)> or /assimilateplayer
 commands.srpcotesia.dendritus.usage=/dendritus
+
+commands.srpcotesia.assimilateplayer.alreadyparasite=%s is already a parasite.
+commands.srpcotesia.assimilateplayer.possessing=%s is possessing a mob.
+commands.srpcotesia.assimilateplayer.dead=%s is either dead or incorporeal.
+commands.srpcotesia.assimilateplayer.success=%s was successfully given the Darwin Award.
+
+commands.srpcotesia.srpcbounty.usage=/srpcbounty <list|clear|listtargets|cleartargets> or /srpcbounty <add|remove> <x> <y> <z> or /srpcbounty <addtarget|removetarget> <player or UUID>
+
+commands.srpcotesia.srpcbounty.disabled=Bounties are currently disabled.
+
+commands.srpcotesia.srpcbounty.list=Active Bounty at x=%d, y=%d, z=%d
+commands.srpcotesia.srpcbounty.list.range=Bounties have %d block range
+commands.srpcotesia.srpcbounty.list.terminal=Bounties have infinite range
+commands.srpcotesia.srpcbounty.list.none=There are no active Bounties.
+
+commands.srpcotesia.srpcbounty.clear=Cleared all active Bounties. The blocks themselves may still remain, but are inert.
+
+commands.srpcotesia.srpcbounty.add.inrange=Position is too close to existing Bounty at x=%d, y=%d, z=%d.
+commands.srpcotesia.srpcbounty.add.incorrectdim=Bounties cannot be placed in this dimension (%d).
+commands.srpcotesia.srpcbounty.add.notloaded=A Bounty cannot be placed in unloaded chunks, if a non-replaceable block is already present, or if blocks cannot be placed there at all.
+commands.srpcotesia.srpcbounty.add.success=A Bounty was successfully placed at x=%d, y=%d, z=%d.
+
+commands.srpcotesia.srpcbounty.remove=A Bounty was successfully removed at x=%d, y=%d, z=%d. The block has been rendered inert.
+
+commands.srpcotesia.srpcbounty.remove.none=There is no Bounty there.
+
+commands.srpcotesia.srpcbounty.listtargets=Currently known Vagrants:
+commands.srpcotesia.srpcbounty.listtargets.uuid=Player with UUID %s
+commands.srpcotesia.srpcbounty.listtargets.player=Player with name %s
+
+commands.srpcotesia.srpcbounty.cleartargets=Cleared the list of known Vagrants.
+
+commands.srpcotesia.srpcbounty.addtarget=Successfully added %s as a known Vagrant.
+commands.srpcotesia.srpcbounty.addtarget.fail=%s has already been flagged as a Vagrant.
+commands.srpcotesia.srpcbounty.addtarget.totalfail=No Vagrants matched the criteria.
+
+commands.srpcotesia.srpcbounty.removetarget=Successfully removed %s from the known Vagrants list.
+commands.srpcotesia.srpcbounty.removetarget.fail=%s has not been flagged as a Vagrant.
+commands.srpcotesia.srpcbounty.removetarget.totalfail=No Vagrants matched the criteria.
+
+
+
 commands.srpcotesia.srpcwell.usage=/srpcwell <get|clear|fix> <dimension id, optional> or /srpcwell <add|remove> <x> <z> <dimension id, optional>
 
+commands.srpcotesia.srpcwell.disabled=Wells are currently disabled.
+
 commands.srpcotesia.srpcwell.empty=There are currently no active Wells.
+
+commands.srpcotesia.srpcwell.get=Active Well at x=%d, z=%d, with %d health in %s (DIM ID %d)
+commands.srpcotesia.srpcwell.clear=Removed all Wells.
+commands.srpcotesia.srpcwell.clear.dim=Removed all Wells in %s (DIM ID %d)
+commands.srpcotesia.srpcwell.add=Well successfully added at x=%d, z=%d, in %s (DIM ID %d)
+commands.srpcotesia.srpcwell.incorrectdim=Wells cannot be placed in that dimension.
+commands.srpcotesia.srpcwell.toomany=There are too many Wells across all dimensions.
+commands.srpcotesia.srpcwell.toomanydim=There are too many Wells in %s (DIM ID %d)
+commands.srpcotesia.srpcwell.remove=Well successfully removed at x=%d, z=%d, in %s (DIM ID %d)
+commands.srpcotesia.srpcwell.remove.none=There is no Well there.
+commands.srpcotesia.srpcwell.nofix=All Wells appear to be valid, or there aren't any.
 
 command.srpcotesia.srpmobcounts.top=========== Parasite Mob Counts  ==========
 command.srpcotesia.srpmobcounts.info=There are %d different parasite entities. %d total parasites were found.
 command.srpcotesia.srpmobcounts.displaying=Displaying %d most frequent:
 command.srpcotesia.srpmobcounts.class=%s: %d
 command.srpcotesia.srpmobcounts.name=%s (%s): %d
-
-commands.srpcotesia.srpcwell.get=Active Well at x=%d, z=%d, with %d health in %s (DIM ID %d)
-commands.srpcotesia.srpcwell.clear=Removed all Wells.
-commands.srpcotesia.srpcwell.clear.dim=Removed all Wells in %s (DIM ID %d)
-commands.srpcotesia.srpcwell.add=Well successfully added at x=%d, z=%d, in %s (DIM ID %d)
-commands.srpcotesia.srpcwell.remove=Well successfully removed at x=%d, z=%d, in %s (DIM ID %d)
-commands.srpcotesia.srpcwell.remove.none=There is no Well there.
-commands.srpcotesia.srpcwell.nofix=All Wells appear to be valid, or there aren't any.
 
 commands.srpcotesia.dendritus.active=Active Stage %s Dendritus at x=%d, y=%d, z=%d, with %d block range
 commands.srpcotesia.dendritus.inactive=Inactive Stage %s Dendritus at x=%d, y=%d, z=%d, with %d block range
@@ -101,11 +167,13 @@ commands.srpcotesia.atimer.disabled=The Armageddon timer is disabled.
 commands.srpcotesia.atimer.query=%d ticks remain.
 
 commands.srpcotesia.ante.disabled=Ante is disabled.
-commands.srpcotesia.ante.query=Ante is currently at %d.
+commands.srpcotesia.ante.query=Ante is currently at %d. The current minimum Ante is %d.
+commands.srpcotesia.ante.recalibrate=Ante has been recalibrated.
 
 death.attack.out_of_time=%1$s ran out of time.
 death.attack.gave_up=%1$s abandoned their body.
 death.attack.gravity_crushing=%1$s was flattened beyond measure.
+death.attack.auricFire=%1$s was ionized by auric flames.
 
 commands.srpcotesia.adapt.adapted=Forced %d entities to adapt to '%s'
 commands.srpcotesia.adapt.cant=Found %d entities which could not adapt
@@ -118,7 +186,7 @@ commands.srpcotesia.setbiomass.success=Successfully set biomass for %s to %d.
 commands.srpcotesia.setbloom.success=Successfully set bloom tier for %s to %d.
 commands.srpcotesia.togglenote.success=Successfully set received Trustworthy Note status for %s to %s.
 commands.srpcotesia.setKillC.success=Successfully set kills contributed for %s to %d.
-commands.srpcotesia.ante.success=Successfully set Ante to %d.
+commands.srpcotesia.ante.success=Successfully set Ante to %d. The current minimum Ante is %d.
 commands.srpcotesia.atimer.success=Successfully set Armageddon timer to %d.
 
 key.srpcotesia.togglehide=Hide/Unhide
@@ -134,6 +202,9 @@ key.categories.srpcotesia=Cotesia Glomerata
 
 entity.srpcotesia.latch.name=Latch
 entity.srpcotesia.factory.name=Factory
+entity.srpcotesia.mote.name=Mote
+
+tooltip.srpcotesia.item.parasitedrop=Can be obtained by using Right Click with any Sword on a placed %s Factory.
 
 item.srpcotesia.factory.name=Factory
 tooltip.srpcotesia.factory.unbound=Unbound
@@ -145,13 +216,14 @@ overlay.srpcotesia.handful=Need an empty hand
 overlay.srpcotesia.pickup=%s to pick up
 overlay.srpcotesia.insert=%s to add biomass
 overlay.srpcotesia.takeout=%s to take out biomass
-overlay.srpcotesia.nocolony=Missing colony
+overlay.srpcotesia.nocolony=Missing Colony
 overlay.srpcotesia.seconds=%d second(s)
-overlay.srpcotesia.factoryblocked=Cannot produce
+overlay.srpcotesia.factoryblocked=Cannot produce parasites
 overlay.srpcotesia.biomass=%d/%d biomass
 overlay.srpcotesia.biomass.cost=%d/%d biomass, Cost: %d biomass
 overlay.srpcotesia.cost=Cost: %d biomass
 overlay.srpcotesia.dispatcher.stored=%d parasites stored.
+overlay.srpcotesia.killC.cooldown=Evolution on cooldown
 overlay.srpcotesia.killC=%d pts (%d needed)
 overlay.srpcotesia.killC.boundless=%d pts (It's beautiful)
 overlay.srpcotesia.killC.upgradeImminent=Are you ready?
@@ -162,7 +234,7 @@ overlay.srpcotesia.copybind=Press %s to copy
 overlay.srpcotesia.dispatcher.retrieve=Press %s to retrieve stored parasites
 overlay.srpcotesia.factory.dissolve=Press %s to dissolve parasite
 
-
+overlay.srpcotesia.catchingup=Point gain is not world-affecting!
 
 item.srpcotesia.brew_sac.name=Brew Sac
 tooltip.srpcotesia.brew_sac.judgemental=Not for you.
@@ -170,19 +242,21 @@ tooltip.srpcotesia.brew_sac.ammo=%d/%d throws
 tooltip.srpcotesia.brew_sac.empty=Empty. Use an Osmosis to modify it!
 tooltip.srpcotesia.brew_sac.cost=%d Biomass to refill
 tooltip.srpcotesia.brew_sac.refill=Hold Use Item to refill
-tooltip.srpcotesia.brew_sac.intensity=Amplifier %s
-tooltip.srpcotesia.brew_sac.damage=Effects deal %d base damage
+tooltip.srpcotesia.brew_sac.intensity=Max Potion Amplifier %s
+tooltip.srpcotesia.brew_sac.damage=Effects deal %s base damage
 tooltip.srpcotesia.brew_sac.stacking=Stacking
 tooltip.srpcotesia.reagent.via=§fWhen added via §bOsmosis§f:
 tooltip.srpcotesia.reagent.adds=§fAdds effect to brew: %s
 tooltip.srpcotesia.reagent.damage=§fChanges brew base damage to %f
 tooltip.srpcotesia.reagent.intensifier=§fIncreases brew amplifier
+tooltip.srpcotesia.reagent.incompatible=§fIncompatible with %s
 
 tooltip.srpcotesia.pointmulti.global=+%s%% Global Evolution Point Gain
 tooltip.srpcotesia.pointmulti.singular=+%s%% Evolution Point Gain
 tooltip.srpcotesia.pointmultidrain=Drains %d XP per second
 
 brew.srpcotesia.potion.name=Applies %s
+brew.srpcotesia.potion.name.max=Applies %s, Max %s
 brew.srpcotesia.emptyPotion.name=Null Potion
 brew.srpcotesia.parasitepotion.desc=Applies this effect to parasites.
 brew.srpcotesia.enemypotion.desc=Applies this effect to non-parasites.
@@ -191,16 +265,29 @@ brew.srpcotesia.harm.desc=Deals magic damage.
 brew.srpcotesia.poisonBane.name=Poison Bane
 brew.srpcotesia.poisonBane.desc=Deals some magic damage, but only if the entity has Poison.
 brew.srpcotesia.witherBane.name=Wither Bane
-brew.srpcotesia.witherBane.desc=Deals some magic damage, but only if the entity has Wither.
+brew.srpcotesia.witherBane.desc=Deals magic damage, but only if the entity has Wither.
 brew.srpcotesia.explosion.name=Explosion
-brew.srpcotesia.explosion.desc=Explodes on direct hits. Does not destroy blocks.
+brew.srpcotesia.explosion.desc=Violently explodes on direct hits, deals some magic damage. Does not destroy blocks.
 brew.srpcotesia.turn.name=Turn
 brew.srpcotesia.turn.desc=Assimilates a Sane mob if it is weakened enough. May produce a Feral mob if the phase permits.
+brew.srpcotesia.repeat.name=Repeat
+brew.srpcotesia.repeat.desc=Applies the effect directly preceding it again.
+brew.srpcotesia.rally.name=Rally
+brew.srpcotesia.rally.desc=Teleports a faraway parasite to the brew's impact location.
+
+item.srpcotesia.itemenhance.name=§6Enhancement Wand
+tooltip.srpcotesia.itemenhance=Target (or use on) a Creature for §6Enhancement
+message.srpcotesia.enhancedmobsdisabled=§6Enhanced Mobs§f are currently disabled.
+
+message.srpcotesia.itemenhance.succeed=§6Mob successfully enhanced.
+message.srpcotesia.itemenhance.repeat=§6This mob is already enhanced.
+message.srpcotesia.itemenhance.fail=§6This mob cannot be enhanced, or mobs cannot be enhanced here.
+message.srpcotesia.itemenhance.parasite=§6Not even remotely possible.
 
 item.srpcotesia.scorned_pearl.name=§cScorned Pearl
 tooltip.srpcotesia.scorned_pearl.parasite1=§cAbsolutely revolting.
 tooltip.srpcotesia.scorned_pearl.parasite2=§4DUMB LUCK ALWAYS SEEMS TO FIND THEM REGARDLESS. GET RID OF THIS.
-tooltip.srpcotesia.scorned_pearl.parasite3=§4BETTER FOR IT TO BE MADE OF YOUR FLESH, RATHER THAN SOMETHING LESS COWARDLY.
+tooltip.srpcotesia.scorned_pearl.parasite3=§4BETTER FOR IT TO BE MADE OF OUR FLESH, RATHER THAN SOMETHING LESS COWARDLY.
 tooltip.srpcotesia.scorned_pearl1=§fSubstantially increases the amount of points removed by a Carcass if used on the central Lure in the offhand.
 tooltip.srpcotesia.scorned_pearl2=§fYou must be in complete darkness in order to use this item.
 tooltip.srpcotesia.scorned_pearl3=§fSeverely damages any parasites in a 10 chunk radius.
@@ -210,21 +297,68 @@ message.srpcotesia.scorned_pearl.dark=You need to be in complete darkness.
 message.srpcotesia.scorned_pearl.cooldown=This won't work during a cooldown.
 message.srpcotesia.scorned_pearl.toolow=This is just overkill.
 
+item.srpcotesia.remnant.name=Remnant
+tooltip.srpcotesia.remnant=§fA palm-sized disc dropped from an §6Enhanced %s.
+tooltip.srpcotesia.remnant.unbound=§fUse on an entity to create that entity's §dRemnant. §fAny recipe involving this item indicates that any §dRemnant§f can be used instead.
+tooltip.srpcotesia.remnant1=§dRemnants§f will drop from §6Enhanced Mobs§f killed by parasites, although a §cVagrant§f must be directly involved.
+tooltip.srpcotesia.remnant.notyet=The §6Enhanced Mobs§f are not strong enough to drop these yet.
+tooltip.srpcotesia.remnant2=§fWill not drop from passive mobs.
+tooltip.srpcotesia.remnant3=§f5 unique Remnants can be used to create §6Chip Fragments§f at a §bLithograph§f.
+
+item.srpcotesia.chip_fragment.name=§6Chip Fragment
+tooltip.srpcotesia.chip_fragment=§fA small piece of circuitry. It's just small enough to be safe to hold.
+tooltip.srpcotesia.chip_fragment1=§fA small piece of something §6much more important.
+tooltip.srpcotesia.chip_fragment2=§fCreated with 5 unique §dRemnants§f at a §bLithograph§f.
+tooltip.srpcotesia.chip_fragment3=§4REVEALED VIA YOUR PERCEPTION. THE OTHERS ARE NONE THE WISER, ALTHOUGH NOT OUT OF INEPTITUDE.
+
+item.srpcotesia.callous_chip.name=§6Callous Chip
+tooltip.srpcotesia.callous_chip=§fAn abnormally warm and unstable computer chip.
+tooltip.srpcotesia.callous_chip1=§fA small piece of something §6much more dangerous.
+tooltip.srpcotesia.callous_chip2=§cI'll need this for further crafting.
+tooltip.srpcotesia.callous_chip3=§4CONVINCING THE OTHERS TO PRODUCE THESE HAS BEEN A FUTILE EFFORT. WE ARE ON OUR OWN.
+
+message.srpcotesia.item.yielding=§bWeakens you if held in the inventory.
+
+item.srpcotesia.signal_jammer.name=§6Signal Jammer
+tooltip.srpcotesia.signal_jammer1=§fPrevents nearby Enhanced Mobs from dealing critical hits for several seconds.
+tooltip.srpcotesia.signal_jammer2=§6> Do not interfere with what you cannot understand.
+tooltip.srpcotesia.signal_jammer3=§6  Your kind brought this upon themselves.
+message.srpcotesia.signal_jammer.waste=§fThere are no §6Enhanced Mobs§f in range.
+
+
+item.srpcotesia.bloodstained_saddle.name=§bBloodstained Saddle
+tooltip.srpcotesia.bloodstained_saddle.fake=§fA saddle torn asunder by internal infection.
+tooltip.srpcotesia.bloodstained_saddle1=§fCan be placed on certain parasites to allow them to be used as a mount.
+tooltip.srpcotesia.bloodstained_saddle2=§fThe item will be consumed. Converting the parasite to biomass (or the parasite dying) will recover the saddle.
+tooltip.srpcotesia.bloodstained_saddle3=§fOnly works on parasites you were involved in creating.
 
 item.srpcotesia.macabre_pearl.name=§bMacabre Pearl
 tooltip.srpcotesia.macabre_pearl.fake=§fA pearl as murky as your future.
 tooltip.srpcotesia.macabre_pearl1=§fCan be used to convince parasites to follow you much more readily.
-tooltip.srpcotesia.macabre_pearl2=§fUsing the item on the parasite will toggle this behavior.
+tooltip.srpcotesia.macabre_pearl2=§fUsing the item on the parasite will toggle this behavior. Using the item while sneaking will forcefully teleport them to you.
 tooltip.srpcotesia.macabre_pearl3=§fOnly works on parasites you were involved in creating.
-tooltip.srpcotesia.macabre_pearl4=§4THE MORE, THE MERRIER.
+tooltip.srpcotesia.macabre_pearl4=§4SOMEONE HAS TO LOOK OUT FOR YOU. YOU MIGHT END UP DOING SOMETHING STUPID.
+
+item.srpcotesia.itemdismiss.name=§aDismissal Wand
+tooltip.srpcotesia.itemdismiss1=Target (or use on) a Parasite for §aRemoval
+tooltip.srpcotesia.itemdismiss.fake=You'd have to be in Creative Mode to force it to, though.
+tooltip.srpcotesia.itemdismiss2=§4JUST YOU AND ME
+
+message.srpcotesia.itemdismiss.unworthy=§fIt seems unwilling.
 
 item.srpcotesia.factory_drop.name=§eFactory Innards
 tooltip.srpcotesia.factory_drop1=§fA gelatinous mass of flesh harvested from a §eFactory§f. It's already falling apart.
-tooltip.srpcotesia.factory_drop2=§4MALLEABILITY TO THIS DEGREE COMES WITH A PRICE, ALTHOUGH WE CANNOT DENY ITS UTILITY.
-tooltip.srpcotesia.factory_drop3=§4IT WOULD BE WISE TO COVER YOUR TRACKS. GET RID OF THIS.
+tooltip.srpcotesia.factory_drop2=§4YOUR "MODIFICATIONS" GIVEN FORM. CHANGE TO THIS DEGREE HAS CONSEQUENCES, FOR US AND FOR YOUR CREATIONS.
+tooltip.srpcotesia.factory_drop3=§4IT WOULD BE WISE TO COVER OUR TRACKS. GET RID OF THIS.
 
 item.srpcotesia.mortifying_tentacle.name=§2Mortifying Tentacle
 tooltip.srpcotesia.mortifying_tentacle=§fA smaller variant of a tentacle present on a §2Preeminent§f parasite body.
+
+item.srpcotesia.bogle_charge.name=§2Bogle Charge
+tooltip.srpcotesia.bogle_charge=§fA smaller variant of a §2Bogle's§f explosive charge.
+
+item.srpcotesia.virulent_breath.name=§aVirulent Breath
+tooltip.srpcotesia.virulent_breath=§fA bottle of Dragon's Breath infected with §aViral§f.
 
 item.srpcotesia.putrid_unit.name=§cPutrid Unit
 tooltip.srpcotesia.putrid_unit1=§fA disorganized clump of neural tissue, sourced from a §cFeral§f parasite.
@@ -237,9 +371,10 @@ tooltip.srpcotesia.item.fearitem=§4You dislike this item.
 tooltip.srpcotesia.item.disruptor=§fDisrupts §1Phasing§f
 tooltip.srpcotesia.item.notdisruptor=§fDoes not disrupt §1Phasing§f
 
-tooltip.srpcotesia.factory.deterrent=Emboldened
+tooltip.srpcotesia.factory.deterrent=Will spawn parasites offensively while held.
 tooltip.srpcotesia.factory.bound=Bound to %s
 tooltip.srpcotesia.factory.tier=Tier: %d
+tooltip.srpcotesia.factory.cannotproduce=Cannot produce parasites, only used for drops.
 tooltip.srpcotesia.factory.created=§cCan be created with %s
 tooltip.srpcotesia.factory.shift=Hold SHIFT for more information
 tooltip.srpcotesia.factory.desc1=Factories are utility parasites that spawn in other parasites.
@@ -253,16 +388,23 @@ tooltip.srpcotesia.factory.desc8=Bound factories will absorb lower tier parasite
 tooltip.srpcotesia.factory.desc9=§cMore spare parts can be made if there are Factories bound to other parasites of the same tier nearby.
 tooltip.srpcotesia.factory.desc10=Unbound factories will distribute biomass to lower tier factories nearby and upgrade certain parasites.
 tooltip.srpcotesia.factory.desc11=Trading certain items with factories will yield evolution points and experience, depending on the item's value. A clock (bloody or not) can be used to check the phase progression.
-tooltip.srpcotesia.factory.desc12=If this factory is Emboldened, it will spawn its bound parasite passively to attack nearby enemies.
+tooltip.srpcotesia.factory.desc12=Deterrent-tier parasite factories, such as that of the Sentry or Seizer, will spawn that parasite passively nearby when held. An enemy must be present.
 tooltip.srpcotesia.factory.desc13=This tutorial can be disabled in the Main config's Client settings.
 
 item.srpcotesia.masticator.name=§aThe Masticator
 tooltip.srpcotesia.masticator1=§fSpews toxic miasma. The miasma infests blocks following Phase %d, generating §aEvolution Points§f.
-tooltip.srpcotesia.masticator2=§fRequires §aFetid "Canisters"§f to function.
+tooltip.srpcotesia.masticator2=§fRequires §aFetid "Canisters"§f to function. Could be improved with a Stage IV Beckon under the right conditions...
 tooltip.srpcotesia.masticator3=§4A WORK OF ART, SHAPED FROM YOUR MEMORIES AND ONE OF OUR OWN.
 tooltip.srpcotesia.masticator4=§4THE ORIGINAL DESIGN WAS FLAWED, AS YOU INTUITED. FIRE HAS NO PLACE HERE.
+
+item.srpcotesia.consecrator.name=§4THE CONSECRATOR
+tooltip.srpcotesia.consecrator1=§fSpews horrid miasma. The miasma infests blocks and, if in range of a §4Node§f, biomes following Phase %d, generating §aEvolution Points§f.
+tooltip.srpcotesia.consecrator2=§fRequires §aFetid "Canisters"§f to function.
+tooltip.srpcotesia.consecrator3=§4CRADLED FLESH AND BONE LAYING CLAIM FROM SEA TO SEA.
+tooltip.srpcotesia.consecrator4=§4MAKE THE GROUND SING.
 tooltip.srpcotesia.masticator.notempty=§aThere's still a bit of juice left
 tooltip.srpcotesia.masticator.notparasite=§fA handheld monstrosity resembling a §aBeckon§f.
+tooltip.srpcotesia.consecrator.notparasite=§fA handheld monstrosity resembling a §aStage IV Beckon§f.
 
 item.srpcotesia.fetid_canister.name=§aFetid "Canister"
 tooltip.srpcotesia.fetid_canister1=§fA dense cocoon of various parasite parts, united by renewed purpose.
@@ -293,6 +435,12 @@ tooltip.srpcotesia.well_divining_rod1=§fEmits a spark in the direction of the n
 tooltip.srpcotesia.well_divining_rod2=§fIf it is in a different dimension, it will mention the dimension's name instead.
 tooltip.srpcotesia.well_divining_rod3=§6> Count your days.
 
+item.srpcotesia.well_magnet.name=§6Well Magnet
+tooltip.srpcotesia.well_magnet1=§fTeleports the nearest §6Well§f in a dimension to within %s blocks of the user.
+tooltip.srpcotesia.well_magnet2=§6> There's a pit of magma somewhere waiting for you. Do us both a favor.
+tooltip.srpcotesia.well_magnet3=§cI think I made it angry
+message.srpcotesia.well_magnet.waste=It would be a waste to teleport a §6Well§f that is only %d blocks away.
+message.srpcotesia.well_magnet.moved=A §6Well§f has been moved.
 
 message.srpcotesia.nowell=There are currently no active §6Wells§f.
 message.srpcotesia.nowellrange=There is no nearby §6Well§f.
@@ -320,16 +468,35 @@ tooltip.srpcotesia.vagrant_divining_rod2=§fDoes not work if the §cVagrant§f i
 tooltip.srpcotesia.vagrant_divining_rod3=§cThat doesn't seem very fair.
 tooltip.srpcotesia.vagrant_divining_rod4=§4DESTROY THIS IMMEDIATELY.
 
-message.srpcotesia.item.disabled=§fThis item has been disabled.
+message.srpcotesia.item.disabled=§cThis item has been disabled.
 message.srpcotesia.novagrants=There are no active §cVagrants§f in this dimension.
 message.srpcotesia.trackedvagrant=You feel a pervasive sense of dread...
 
 tile.srpcotesia.gloom_torch.name=§eGloom Torch
 tooltip.srpcotesia.gloom_torch=§4AN IMPROVEMENT.
 
-
 tile.srpcotesia.beckonh.name=§aBeckon Harbringer
-tooltip.srpcotesia.beckonh=§fCan be used to create a Beckon. Interact to give it biomass.
+tooltip.srpcotesia.beckonh=§fCan be used to create a §aBeckon§f. Interact to give it biomass.
+
+tooltip.srpcotesia.dispatchern1=§fCan be used to create a §cDispatcher§f. Interact to give it biomass.
+tooltip.srpcotesia.dispatchern2=§fParasites have a chance to place this if they kill enough foes.
+tooltip.srpcotesia.dispatchern3=§fCan also be created using a §cNidus Accumulator§f.
+
+tooltip.srpcotesia.evclock1=§fIndicates the current amount of globally accrued Evolution Points, as well as the current Evolution Phase.
+tooltip.srpcotesia.evclock2=§fAlso reads out the current Evolution Cooldown, if one is active.
+
+
+
+item.srpcotesia.electroreceptor.name=§eElectroreceptor
+tooltip.srpcotesia.electroreceptor=§fCan be used on a parasite to read their §ckillcount§f.
+tooltip.srpcotesia.electroreceptor.bounty=§fIf used on an §6Enhanced Mob§f, it will partially reveal the location of a §6Bounty§f. Multiple uses will likely be necessary.
+
+message.srpcotesia.electroreceptor=%s has %s kills.
+message.srpcotesia.electroreceptor.player=%s has %s biomass and has contributed %s kills.
+message.srpcotesia.electroreceptor.bounty.x=X=%d
+message.srpcotesia.electroreceptor.bounty.y=Y=%d
+message.srpcotesia.electroreceptor.bounty.z=Z=%d
+
 
 message.srpcotesia.nearbyvenkrol=THERE IS ALREADY ONE NEARBY.
 message.srpcotesia.notready=YOU ARE NOT READY. NOT YET.
@@ -370,10 +537,25 @@ tooltip.srpcotesia.dendritus2=§fAugments a §cDispatcher§f to apply §1Phasing
 tooltip.srpcotesia.dendritus3=§fMust be given to the Dispatcher via pressing %s.
 tooltip.srpcotesia.dendritus4=§fIf placed manually, it can be activated via pressing %s.
 
+tile.srpcotesia.bounty.name=§6Bounty
+tooltip.srpcotesia.bounty1=§fEnhanced Mobs will place §6Bounties§f to record known §cVagrants§f in an area. All §6Bounties§f in a dimension will share data amongst themselves.
+tooltip.srpcotesia.bounty2=§fAll §6Enhanced Mobs§f that spawn in range will share this knowledge, and their prevalence will be increased in tandem.
+
+tooltip.srpcotesia.bountydisabled=§6Bounties§f are currently disabled.
+
+message.srpcotesia.bounty.created=§fA §6Bounty§f has been placed.
+message.srpcotesia.bounty.notify=§fA §6Bounty§f has been notified.
 
 tile.srpcotesia.osmosis.name=§bOsmosis
 tooltip.srpcotesia.osmosis1=§fModifies §9Brew Sacs§f depending on the provided §9reagent§f. Right click with a Sac or viable §9reagent§f to put it in.
 tooltip.srpcotesia.osmosis2=§fViable §9reagents§f will show their effect in their tooltip.
+
+tile.srpcotesia.lithograph.name=§bLithograph
+tooltip.srpcotesia.lithograph1=§fExtracts data from §dRemnants§f to produce §6Chip Fragments§f. Right click with a unique §dRemnant§f to put it in.
+tooltip.srpcotesia.lithograph2=§fOnce it contains 5 §dRemnants§f, it will begin extraction.
+
+tile.srpcotesia.lithograph.conflict=That Remnant is already stored.
+tile.srpcotesia.lithograph.full=There are no empty slots.
 
 item.srpcotesia.booster_si.name=§6Phase Booster
 item.srpcotesia.booster_sii.name=§6Contained Phase Booster
@@ -390,12 +572,42 @@ tooltip.srpcotesia.soulless_core1=§fA §eLiving Core§f sapped of lifeforce.
 tooltip.srpcotesia.soulless_core2=§fCan be used to obtain other core variants without killing parasites. Interact with the required parasite while holding this.
 tooltip.srpcotesia.soulless_core3=§4A MEANS TO AN END.
 
+tooltip.srpcotesia.vengence_core=§cI should use a §eSoulless Core§c on an §6Adapted§c parasite instead. No killing required.
+tooltip.srpcotesia.wrathful_core=§cI should to use a §eSoulless Core§c on a §ePure§c parasite instead. No killing required.
+
+
+item.srpcotesia.nidus_accumulator.name=§cNidus Accumulator
+tooltip.srpcotesia.nidus_accumulator=§fA swollen scab resembling a §cDispatcher Nidus§f.
+tooltip.srpcotesia.nidus_accumulator1=§fCollects a kill every time its bearer kills a mob. Must be in the Hotbar to collect kills.
+tooltip.srpcotesia.nidus_accumulator2=§fIf enough kills are collected, it will turn into a §cDispatcher Nidus§f.
+tooltip.srpcotesia.nidus_accumulator3=§fCurrent Killcount: %d
+tooltip.srpcotesia.nidus_accumulator4=§4CREATION
+
+item.srpcotesia.pristine_matter.name=§aPristine Matter
+tooltip.srpcotesia.pristine_matter=§fA mound of glowing flesh harvested from a §aStage III/IV Beckon§f. Used for crafting.
+
+item.srpcotesia.pact.name=§aThe Pact
+tooltip.srpcotesia.pact=§fA parasitic scroll of unknown origin.
+tooltip.srpcotesia.pact1=§fCan be used to §4dismiss all currently active parasites§f, excluding §aNexus versions§f, within loaded chunks. Does not work during an Evolution Cooldown, or on parasites maintaining some sort of structure.
+tooltip.srpcotesia.pact2=§fIf used on a §aNexus version§f, excluding §eFactories§f, it will also dismiss all §aNexus version§f at or below its stage.
+tooltip.srpcotesia.pact3=§fIf used on a parasite you made, non-despawning parasites that you created will be dismissed as well. Again, excluding §eFactories§f, and occurs alongside the previous.
+tooltip.srpcotesia.pact4=§fA §aScent Gland§f will be generated referencing the highest tier parasites dismissed, excluding anything rooted to the ground or made by you. Sneaking will prevent this, not consuming the item in the process.
+tooltip.srpcotesia.pact5=§4JUSTIFYING THIS CONCEPT WAS A DIFFICULT TASK.
+
+message.srpcotesia.pact.empty=There aren't any parasites that can be dismissed.
+message.srpcotesia.pact.emptyscentremoved=§cThere aren't any parasites which could fill the scent, but parasites were removed.
+
+item.srpcotesia.scent_gland.name=§aScent Gland
+tooltip.srpcotesia.scent_gland=§fResembles a Pepper, or a glowing Ink Sac. It smells awful.
+tooltip.srpcotesia.scent_gland1=§cSmells like a weapon.
+tooltip.srpcotesia.scent_gland2=§fDoes not work if the current Evolution Phase does not permit Scents or Collective Consciousness.
+tooltip.srpcotesia.scent_gland3=§fAttacking an entity with this calls upon the following parasites:
+tooltip.srpcotesia.scent_gland.empty=§fNo parasites are recorded. Use §aThe Pact§f to create a proper one.
+
 item.srpcotesia.moldered_segments.name=§eMoldered Segments
 tooltip.srpcotesia.moldered_segments1=§fA pair of discarded flesh chunks. It seems to be useless.
 tooltip.srpcotesia.moldered_segments2=§cIt needs a §aStage I Beckon§c.
 tooltip.srpcotesia.moldered_segments3=§4A GIFT GIVEN TIME TO FESTER. WE WILL SEE WHAT YOU MAKE OF IT.
-
-
 
 item.srpcotesia.trojan_note.name=Trustworthy Note
 tooltip.srpcotesia.trojan_note=URGENT
@@ -442,11 +654,12 @@ message.srpcotesia.alreadyinfected=NO DOUBLE JEOPARDY.
 message.srpcotesia.notefailphase=It snaps shut. They must have found it redundant.
 message.srpcotesia.notefaildim=It won't budge. It seems weaker in this dimension.
 message.srpcotesia.notefailday=It won't budge. Maybe try again when its darker out?
+message.srpcotesia.notefailpossessing=The note appears to be confused. You must obtain your original vessel.
 message.srpcotesia.notefailmoon=It won't budge. Perhaps the moon phase is wrong.
 message.srpcotesia.notefail=It won't budge. Maybe try again later?
-message.srpcotesia.rpl=You feel a sudden emptiness...
-message.srpcotesia.rpl.burning=A scorching pain sears your temple...
-message.srpcotesia.well.subtract=A distant threat grows stronger...
+#message.srpcotesia.rpl=You feel a sudden emptiness...
+#message.srpcotesia.rpl.burning=A scorching pain sears your temple...
+message.srpcotesia.well.subtract=A §6Well§f has stolen points.
 
 message.srpcotesia.addpoints=Successfully added %d evolution points!
 message.srpcotesia.evocooldown=Evolution is currently on cooldown.
@@ -466,6 +679,8 @@ message.dendritus.inrange=There is already a Dendritus at %d, %d, %d
 
 message.srpcotesia.following=This parasite is now following you.
 message.srpcotesia.notfollowing=This parasite is no longer following you.
+message.srpcotesia.macabre_pearl.nexus=This parasite is yours, but it cannot follow you.
+message.srpcotesia.saddled=This parasite is now saddled.
 message.srpcotesia.didntmake=You didn't make this one.
 
 message.srpcotesia.masticator.empty=You need Fetid Canisters to operate this.
@@ -498,6 +713,10 @@ gui.jei.category.srpcotesia.factory.tierabove=Tier %d+
 gui.jei.category.srpcotesia.factory.pts=§4+%d Evolution Points
 gui.jei.category.srpcotesia.factory=§4Factory Trade
 gui.jei.category.srpcotesia.parasite_transmute=§cParasite Transmutation
+gui.jei.category.srpcotesia.lithography=§bLithography
+gui.jei.category.srpcotesia.lithography.warning1=Combinations shown here are examples, not required.
+gui.jei.category.srpcotesia.lithography.warning2=Order does not matter. Any unique set of 5 will suffice.
+
 gui.jei.category.srpcotesia.osmosis=§bOsmosis Brewing
 gui.jei.category.srpcotesia.reclamation=§bReclamation
 gui.jei.category.srpcotesia.reclamation.xp=§4+%d XP
@@ -510,6 +729,9 @@ enchantment.srpcotesia.fluidity.desc=§fReduces the time it takes for a Factory 
 
 enchantment.srpcotesia.dense_tissue=§bDense Tissue
 enchantment.srpcotesia.dense_tissue.desc=§fCauses parasites spawned by a Factory to have more max HP.
+
+enchantment.srpcotesia.flaying=§5Flaying
+enchantment.srpcotesia.flaying.desc=§fCauses parasites spawned by a Factory to have more attack damage.
 
 enchantment.srpcotesia.cunning=§eCunning
 enchantment.srpcotesia.cunning.desc=§fIncreases Minimum Damage dealt by spawned parasites.
@@ -576,7 +798,20 @@ tooltip.srpcotesia.guide_book.flavor1=§cThe majority of the pages have been tor
 tooltip.srpcotesia.guide_book.flavor2=§4SOMETHING IS VERY WRONG WITH THIS BOOK. IT REFERENCES EVENTS WE DO NOT RECALL.
 tooltip.srpcotesia.guide_book.disabled=Install Patchouli to use this item!
 
-//guide_book json key
-gui.srpcotesia.guide_book.name=§eHyperbiology and You
-gui.srpcotesia.guide_book.landingtext=A preparationary encyclopedia of sorts on the parasites and their capabilities.$(br2)$(c)A book is substantially less helpful if you tear 90% of the pages out. This thing looks more like a binder than a book.$(br)Not that it'll stop me from adding my own, of course.
-gui.srpcotesia.guide_book.subtitle=Vol. 8
+message.srpcotesia.infect=You have successfully infected a creature. (+%d)
+
+message.srpcotesia.hyperarmor=I need to hit them harder than that!
+message.srpcotesia.defense=Keep attacking. %d defense remains.
+message.srpcotesia.nodefense=Keep attacking.
+#message.srpcotesia.catchup=The points I'm getting are of no substance, since there's an Evolution Cooldown.
+
+message.srpcotesia.dissolution.possess=This one is incompatible.
+message.srpcotesia.dissolution.nothing=This one won't work.
+message.srpcotesia.dissolution.possessing=IT HAS MADE ROOM FOR US. BE GRATEFUL.
+
+message.srpcotesia.bounty.intervention=Something is following you
+
+
+subtitles.threat.well=§6Well§f forms
+subtitles.threat.bounty=§6Bounty§f is placed
+subtitles.threat.discovered=§6Enhanced Mob§f discovers §cVagrant§f

--- a/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
@@ -223,6 +223,7 @@ overlay.srpcotesia.biomass=%d/%d 生物质
 overlay.srpcotesia.biomass.cost=%d/%d 生物质，消耗：%d 生物质
 overlay.srpcotesia.cost=需要花费：%d 生物质
 overlay.srpcotesia.dispatcher.stored=已存储寄生体%d
+overlay.srpcotesia.killC.cooldown=演化阶段冷却中
 overlay.srpcotesia.killC=%d 点数（需求 %d）
 overlay.srpcotesia.killC.boundless=%d 点数（干得好）
 overlay.srpcotesia.killC.upgradeImminent=准备好了吗？

--- a/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
@@ -112,8 +112,8 @@ commands.srpcotesia.srpcbounty.list.none=这里没有活动中的悬赏。
 commands.srpcotesia.srpcbounty.clear=清除所有活动中的悬赏。方块本身可能仍然存在，但已失去效用。
 
 commands.srpcotesia.srpcbounty.add.inrange=位置与现有的位于 x=%d，y=%d，z=%d 的悬赏过于接近。
-commands.srpcotesia.srpcbounty.add.incorrectdim=悬赏无法被放置于这个维度。（%d）。
-commands.srpcotesia.srpcbounty.add.notloaded=如果已存在不可替换的方块，或者根本无法在此处放置方块，则悬赏无法放置于未加载的区块。
+commands.srpcotesia.srpcbounty.add.incorrectdim=悬赏无法被放置于这个维度（%d）。
+commands.srpcotesia.srpcbounty.add.notloaded=悬赏无法放置于该未加载区块：此处已存在不可替换的方块，或者完全无法在此放置方块。
 commands.srpcotesia.srpcbounty.add.success=一个悬赏已成功放置于 x=%d，y=%d，z=%d。
 
 commands.srpcotesia.srpcbounty.remove=位于 x=%d，y=%d，z=%d 的悬赏已成功移除。该方块已失效。
@@ -148,7 +148,7 @@ commands.srpcotesia.srpcwell.clear.dim=已移除%s的所有井口。（维度 ID
 commands.srpcotesia.srpcwell.add=井口已成功添加至x=%d，z=%d，%s（维度 ID %d）
 commands.srpcotesia.srpcwell.incorrectdim=无法在那一维度安置井口。
 commands.srpcotesia.srpcwell.toomany=各个维度存在的井口过多了。
-commands.srpcotesia.srpcwell.toomanydim=%s存在的井口过多了。（维度 ID %d）
+commands.srpcotesia.srpcwell.toomanydim=%s存在的井口过多了（维度 ID %d）
 commands.srpcotesia.srpcwell.remove=已成功移除x=%d，z=%d，%s（维度 ID %d）的井口。
 commands.srpcotesia.srpcwell.remove.none=这里没有井口。
 commands.srpcotesia.srpcwell.nofix=所有井口都已生效，或根本没有井口。
@@ -181,7 +181,7 @@ commands.srpcotesia.adapt.cant=发现 %d 个无法适应的实体
 commands.srpcotesia.setbloom.positive=值必须为正数！
 commands.srpcotesia.setKillC.between=值必须在 0 到 %d 之间！
 
-commands.srpcotesia.toggleparasite.success=已成功将寄生体状态设置给 %s。
+commands.srpcotesia.toggleparasite.success=已成功将 %s 的寄生体状态设置为 %s。
 commands.srpcotesia.setbiomass.success=已成功将该生物质状态设置给 %d。
 commands.srpcotesia.setbloom.success=已成功将该进化阶段设置给 %d。
 commands.srpcotesia.togglenote.success=已成功将 %s 可靠的信函获取状态切换至 %s。
@@ -204,7 +204,7 @@ entity.srpcotesia.latch.name=寄染索
 entity.srpcotesia.factory.name=寄生巢穴
 entity.srpcotesia.mote.name=微尘
 
-tooltip.srpcotesia.item.parasitedrop=可用任意一种剑右键已放置的 %s §7寄生巢穴获取。
+tooltip.srpcotesia.item.parasitedrop=可用任意一种剑右击已放置的%s§7寄生巢穴获取。
 
 item.srpcotesia.factory.name=寄生巢穴
 tooltip.srpcotesia.factory.unbound=未绑定
@@ -273,13 +273,13 @@ brew.srpcotesia.turn.desc=在生物足够虚弱时同化该生物。如果演化
 brew.srpcotesia.repeat.name=重复
 brew.srpcotesia.repeat.desc=再次施加前述的效果。
 brew.srpcotesia.rally.name=集结
-brew.srpcotesia.rally.desc=将远处的某只寄生体传送至酿造囊的命中位置。
+brew.srpcotesia.rally.desc=将远处的某只寄生体传送至酿造囊的受击位置。
 
 item.srpcotesia.itemenhance.name=§6强化之杖
 tooltip.srpcotesia.itemenhance=指向某个生物（或将之对某个生物使用），以§6强化§r生物
 message.srpcotesia.enhancedmobsdisabled=§6强化生物§f目前已被禁用。
 
-message.srpcotesia.itemenhance.succeed=§6生物已强化。
+message.srpcotesia.itemenhance.succeed=§6生物强化成功。 
 message.srpcotesia.itemenhance.repeat=§6该生物已被强化。
 message.srpcotesia.itemenhance.fail=§6该生物无法被强化，或该生物无法在此强化。
 message.srpcotesia.itemenhance.parasite=§6这根本不可能办到。
@@ -303,12 +303,12 @@ tooltip.srpcotesia.remnant.unbound=§f在实体上使用它便可制作该实体
 tooltip.srpcotesia.remnant1=§d遗骸§f会由遭寄生体击杀的§6强化生物§f掉落，不过，§c漫游者§f必须直接参与这一过程。
 tooltip.srpcotesia.remnant.notyet=§6强化生物§f尚未强大到掉落遗骸。
 tooltip.srpcotesia.remnant2=§f被动生物不会掉落该物品。
-tooltip.srpcotesia.remnant3=§f5 个不同的遗骸可用于制作§b蚀刻机§f上的§6芯片节段§f。
+tooltip.srpcotesia.remnant3=§f5 个不同的遗骸可用于在§b蚀刻机§f中制作§6芯片节段§f。
 
 item.srpcotesia.chip_fragment.name=§6芯片节段
 tooltip.srpcotesia.chip_fragment=§f一块小小的电路板。它小巧玲珑，可以安全地手持。
 tooltip.srpcotesia.chip_fragment1=§6某些更重要之物§f的一小部分。
-tooltip.srpcotesia.chip_fragment2=§f使用 5 个不同§d遗骸§f制作，用在§b蚀刻机§f上。
+tooltip.srpcotesia.chip_fragment2=§f在§b蚀刻机§f中使用 5 个不同的§d遗骸§f制作。
 tooltip.srpcotesia.chip_fragment3=§4用你的知觉来揭露它。其他同胞对此一无所知，尽管这并非因为它们的无能。
 
 item.srpcotesia.callous_chip.name=§6厚实芯片
@@ -340,7 +340,7 @@ tooltip.srpcotesia.macabre_pearl3=§f只对你曾参与创造的寄生体有效�
 tooltip.srpcotesia.macabre_pearl4=§4总得有什么罩着你。你最后总会做些傻事。
 
 item.srpcotesia.itemdismiss.name=§a溶解之杖
-tooltip.srpcotesia.itemdismiss1=指向某个寄生体（或将之对某个寄生体使用），将之§a清除
+tooltip.srpcotesia.itemdismiss1=指向某个寄生体（或对其使用），将之§a清除
 tooltip.srpcotesia.itemdismiss.fake=不过，你必须处于创造模式才能将它强制溶解。
 tooltip.srpcotesia.itemdismiss2=§4仅有你我。
 
@@ -398,13 +398,13 @@ tooltip.srpcotesia.masticator3=§4一件由你的记忆和我们自己的记忆�
 tooltip.srpcotesia.masticator4=§4正如你的直觉所述，最初的设计是有缺陷的。火在此百无一用。
 
 item.srpcotesia.consecrator.name=§4祭献瘴气枪
-tooltip.srpcotesia.consecrator1=§f喷出恐怖的瘴气。瘴气可侵袭方块，且演化 %d 阶时，如果在§4节点§f范围内将制造群系，并增加§a进化点数§f。
+tooltip.srpcotesia.consecrator1=§f喷出恐怖的瘴气。如果在§4节点§f范围内，且处于演化 %d 阶时，瘴气可在侵袭方块的同时制造出群系，并增加§a进化点数§f。
 tooltip.srpcotesia.consecrator2=§f需要§a腥臭“滤毒罐”§f运作。
 tooltip.srpcotesia.consecrator3=§4从海到海，骨肉相连。
 tooltip.srpcotesia.consecrator4=§4令大地歌唱。
 tooltip.srpcotesia.masticator.notempty=§a里面还剩一点汁液
 tooltip.srpcotesia.masticator.notparasite=§f一只类似§a召唤柱§f的手持式畸变体。
-tooltip.srpcotesia.consecrator.notparasite=§f一只类似§aIV 阶召唤柱§f的手持式畸变体。
+tooltip.srpcotesia.consecrator.notparasite=§f一只类似 §aIV 阶召唤柱§f的手持式畸变体。
 
 item.srpcotesia.fetid_canister.name=§a腥臭“滤毒罐”
 tooltip.srpcotesia.fetid_canister1=§f由寄生体各部分组成的致密茧状物，因新的目的结合在一起。
@@ -436,8 +436,8 @@ tooltip.srpcotesia.well_divining_rod2=§f如果它在一个不同的维度，则
 tooltip.srpcotesia.well_divining_rod3=§6> 算算你的天数。
 
 item.srpcotesia.well_magnet.name=§6井口磁铁
-tooltip.srpcotesia.well_magnet1=§f将该维度在 %s 格范围内最近的§6井口§f传送至使用者。
-tooltip.srpcotesia.well_magnet2=§6> 某处有个熔岩池等着你呢。帮我们个忙。
+tooltip.srpcotesia.well_magnet1=§f将该维度最近的§6井口§f传送至使用者 %s 格范围内。
+tooltip.srpcotesia.well_magnet2=§6> 某处有个岩浆池等着你呢。帮我们个忙。
 tooltip.srpcotesia.well_magnet3=§c我想我把它惹毛了
 message.srpcotesia.well_magnet.waste=将仅有 %d 格距离的§6井口§f传送来也太浪费了。
 message.srpcotesia.well_magnet.moved=一个§6井口§f已被移动。
@@ -483,7 +483,7 @@ tooltip.srpcotesia.dispatchern2=§f寄生体在杀敌数量足够时，便有概
 tooltip.srpcotesia.dispatchern3=§f也可以通过§c胞窝累聚体§f制造。
 
 tooltip.srpcotesia.evclock1=§f显示当前全局累计的演化点数，也包括当前的演化阶段。
-tooltip.srpcotesia.evclock2=§f如果目前处于演化阶段冷却时间，也会读出当前的演化冷却时间。
+tooltip.srpcotesia.evclock2=§f如果目前处于演化阶段冷却时间，也会显示当前的演化冷却时间。
 
 
 
@@ -548,10 +548,10 @@ message.srpcotesia.bounty.notify=§f一个§6悬赏§f已进行通报。
 
 tile.srpcotesia.osmosis.name=§b渗透活化器
 tooltip.srpcotesia.osmosis1=§f根据放入的§9反应物§f对§9酿造囊§f进行改造。用酿造囊或§9反应物§f右键点击放入。
-tooltip.srpcotesia.osmosis2=§f工具提示栏内会显示被活化后§9反应物§f的效果。
+tooltip.srpcotesia.osmosis2=§f提示框内会显示被活化后§9反应物§f的效果。  
 
 tile.srpcotesia.lithograph.name=§b蚀刻机
-tooltip.srpcotesia.lithograph1=§f从§d遗骸§f提取数据用于生产§6芯片节段§f。拿着§d遗骸§f鼠标左击将之放入。
+tooltip.srpcotesia.lithograph1=§f从§d遗骸§f提取数据用于生产§6芯片节段§f。手持不同的§d遗骸§f右键点击放入。
 tooltip.srpcotesia.lithograph2=§f当它包含了 5 份§d遗骸§f，它将开始数据提取。
 
 tile.srpcotesia.lithograph.conflict=这一遗骸已被储存。
@@ -584,14 +584,14 @@ tooltip.srpcotesia.nidus_accumulator3=§f目前的击杀计数：%d
 tooltip.srpcotesia.nidus_accumulator4=§4创造
 
 item.srpcotesia.pristine_matter.name=§a原生物质
-tooltip.srpcotesia.pristine_matter=§f从§aIII/IV 阶召唤柱§f上收集到的一小团发光的肉。用于合成。
+tooltip.srpcotesia.pristine_matter=§f从 §aIII/IV 阶召唤柱§f上收集到的一小团发光的肉。用于合成。
 
 item.srpcotesia.pact.name=§a契约
 tooltip.srpcotesia.pact=§f一份来历不明的寄染卷轴。
-tooltip.srpcotesia.pact1=§f可用于在一个已加载的区块内§4遣散所有目前活动中的寄生体§f，不包括§a连结种§f。在全局演化阶段冷却时无法生效。也无法对维持某些生成结构的寄生体生效。
-tooltip.srpcotesia.pact2=§f如果对除§e寄生巢穴§f以外的§a连结种§f使用，它也会遣散所有这一阶段或者低于该阶段的§a连结种§f。
-tooltip.srpcotesia.pact3=§f如果对你所创造的寄生体使用，不会被刷新消失的寄生体也会被遣散。这同样不包括§e寄生巢穴§f，并与前者同时发生。
-tooltip.srpcotesia.pact4=§f一个§a循迹腺体§f会按照你所遣散的最高级别的寄生体生成（扎根于地面或由你创造的东西除外）。潜行可以避免这种情况发生，物品也不会被消耗。
+tooltip.srpcotesia.pact1=§f可用于在已加载的区块内§4遣散除§a连结种§4以外所有正在活动中的寄生体§f。在全局演化阶段冷却时该物品无法生效。且该物品也无法对正在维持某些结构的寄生体生效。
+tooltip.srpcotesia.pact2=§f如果对除§e寄生巢穴§f以外的§a连结种§f使用该物品，它也会遣散所有这一阶段或者低于该阶段的§a连结种§f。
+tooltip.srpcotesia.pact3=§f如果对你所创造的寄生体使用该物品，不会自然消失的寄生体也会被遣散。这同样不包括§e寄生巢穴§f，而前述的遣散机制同样会生效。
+tooltip.srpcotesia.pact4=§f此后，一份§a循迹腺体§f将会生成，它会记录下你所遣散的最高级别的寄生体（扎根于地面或由你创造的寄生体除外）。潜行可以避免此事发生，过程中物品也不会被消耗。
 tooltip.srpcotesia.pact5=§4证明这一概念的合理性是项艰巨的任务。
 
 message.srpcotesia.pact.empty=这里没有任何寄生体可供遣散。

--- a/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
@@ -232,7 +232,6 @@ overlay.srpcotesia.trade=按下%s交易
 overlay.srpcotesia.copybind=按下%s拷贝
    
 overlay.srpcotesia.dispatcher.retrieve=按下%s取回存储的寄生体
-
 overlay.srpcotesia.factory.dissolve=按下%s溶解寄生体
 
 overlay.srpcotesia.catchingup=点数获取不与当前世界绑定！
@@ -484,7 +483,7 @@ tooltip.srpcotesia.dispatchern2=§f寄生体在杀敌数量足够时，便有概
 tooltip.srpcotesia.dispatchern3=§f也可以通过§c胞窝累聚体§f制造。
 
 tooltip.srpcotesia.evclock1=§f显示当前全局累计的演化点数，也包括当前的演化阶段。
-tooltip.srpcotesia.evclock2=§f同时会读出当前演化冷却时间，如果这会有的话。
+tooltip.srpcotesia.evclock2=§f如果目前处于演化阶段冷却时间，也会读出当前的演化冷却时间。
 
 
 
@@ -511,7 +510,7 @@ tooltip.srpcotesia.cartilage1=§f深色的海绵状建筑方块，由§4群系§
 tooltip.srpcotesia.cartilage2=§f不会扩散§4群系§f。
 
 tile.srpcotesia.chitin.name=§e甲壳质
-tooltip.srpcotesia.chitin=§f一种非常致密坚固的方块，类似§7黑曜石。
+tooltip.srpcotesia.chitin=§f一种非常致密坚固的方块，类似§7黑曜石§f。
 
 tooltip.srpcotesia.parasitelightsource1=§f允许寄生体生成在附近。
 tooltip.srpcotesia.parasitelightsource2=§f使相邻光源成为可接受的光源。
@@ -592,16 +591,16 @@ tooltip.srpcotesia.pact=§f一份来历不明的寄染卷轴。
 tooltip.srpcotesia.pact1=§f可用于在一个已加载的区块内§4遣散所有目前活动中的寄生体§f，不包括§a连结种§f。在全局演化阶段冷却时无法生效。也无法对维持某些生成结构的寄生体生效。
 tooltip.srpcotesia.pact2=§f如果对除§e寄生巢穴§f以外的§a连结种§f使用，它也会遣散所有这一阶段或者低于该阶段的§a连结种§f。
 tooltip.srpcotesia.pact3=§f如果对你所创造的寄生体使用，不会被刷新消失的寄生体也会被遣散。这同样不包括§e寄生巢穴§f，并与前者同时发生。
-tooltip.srpcotesia.pact4=§f一个§a气味腺体§f会按照你所遣散的最高级别的寄生体生成（扎根于地面或由你创造的东西除外）。潜行可以避免这种情况发生，物品也不会被消耗。
+tooltip.srpcotesia.pact4=§f一个§a循迹腺体§f会按照你所遣散的最高级别的寄生体生成（扎根于地面或由你创造的东西除外）。潜行可以避免这种情况发生，物品也不会被消耗。
 tooltip.srpcotesia.pact5=§4证明这一概念的合理性是项艰巨的任务。
 
 message.srpcotesia.pact.empty=这里没有任何寄生体可供遣散。
-message.srpcotesia.pact.emptyscentremoved=§c这里没有任何寄生体可供填补气味因子，但寄生体也已移除。
+message.srpcotesia.pact.emptyscentremoved=§c这里没有任何寄生体可供填补踪迹因子，但寄生体也已移除。
 
-item.srpcotesia.scent_gland.name=§a气味腺体
+item.srpcotesia.scent_gland.name=§a循迹腺体
 tooltip.srpcotesia.scent_gland=§f味道像是胡椒粉或荧光墨囊。很难闻。
 tooltip.srpcotesia.scent_gland1=§c闻起来像是武器。
-tooltip.srpcotesia.scent_gland2=§f在演化阶段不足以支持气味因子和统一意志存在时不生效。
+tooltip.srpcotesia.scent_gland2=§f在演化阶段不足以支持踪迹因子和统一意志存在时不生效。
 tooltip.srpcotesia.scent_gland3=§f使用它攻击实体时，将召唤下列寄生体：
 tooltip.srpcotesia.scent_gland.empty=§f没有任何寄生体记录在内。使用§a契约§f创建一个合适的腺体。
 
@@ -716,7 +715,7 @@ gui.jei.category.srpcotesia.factory=§4巢穴交易
 gui.jei.category.srpcotesia.parasite_transmute=§c寄生体转变
 gui.jei.category.srpcotesia.lithography=§b蚀刻
 gui.jei.category.srpcotesia.lithography.warning1=此处的显示的配方只是示例，并非必须。
-gui.jei.category.srpcotesia.lithography.warning2=材料顺序并不重要。任何一组独特的 5 个遗骸都可以。
+gui.jei.category.srpcotesia.lithography.warning2=材料顺序并不重要。任意一组 5 个不同的遗骸都可以。
 
 gui.jei.category.srpcotesia.osmosis=§b渗透酿造
 gui.jei.category.srpcotesia.reclamation=§b回收
@@ -807,7 +806,7 @@ message.srpcotesia.defense=继续攻击。还剩 %d 防御值。
 message.srpcotesia.nodefense=继续攻击。
 #message.srpcotesia.catchup=The points I'm getting are of no substance, since there's an Evolution Cooldown.
 
-message.srpcotesia.dissolution.possess=这只与你并不相容。
+message.srpcotesia.dissolution.possess=这与你并不相容。
 message.srpcotesia.dissolution.nothing=这根本行不通。
 message.srpcotesia.dissolution.possessing=它已经为我们腾出了空间。心怀感激吧。
 

--- a/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
@@ -397,7 +397,7 @@ tooltip.srpcotesia.masticator2=§f需要§a腥臭“滤毒罐”§f运作。
 tooltip.srpcotesia.masticator3=§4一件由你的记忆和我们自己的记忆共同缔造的艺术品。
 tooltip.srpcotesia.masticator4=§4正如你的直觉所述，最初的设计是有缺陷的。火在此百无一用。
 
-item.srpcotesia.consecrator.name=§4祝圣瘴气枪
+item.srpcotesia.consecrator.name=§4祭献瘴气枪
 tooltip.srpcotesia.consecrator1=§f喷出恐怖的瘴气。瘴气可侵袭方块，且演化 %d 阶时，如果在§4节点§f范围内将制造群系，并增加§a进化点数§f。
 tooltip.srpcotesia.consecrator2=§f需要§a腥臭“滤毒罐”§f运作。
 tooltip.srpcotesia.consecrator3=§4从海到海，骨肉相连。
@@ -438,7 +438,7 @@ tooltip.srpcotesia.well_divining_rod3=§6> 算算你的天数。
 item.srpcotesia.well_magnet.name=§6井口磁铁
 tooltip.srpcotesia.well_magnet1=§f将该维度在 %s 格范围内最近的§6井口§f传送至使用者。
 tooltip.srpcotesia.well_magnet2=§6> 某处有个岩浆池等着你呢。帮我们个忙。
-tooltip.srpcotesia.well_magnet3=§c我想我把它惹火了
+tooltip.srpcotesia.well_magnet3=§c我想我把它惹毛了
 message.srpcotesia.well_magnet.waste=将仅有 %d 格距离的§6井口§f传送来也太浪费了。
 message.srpcotesia.well_magnet.moved=一个§6井口§f已被移动。
 
@@ -815,7 +815,7 @@ message.srpcotesia.bounty.intervention=有什么东西在跟着你。
 
 subtitles.threat.well=§6井口§f已形成
 subtitles.threat.bounty=§6悬赏§f已放置
-subtitles.threat.discovered=§6强化生物§f记录下了一只§c漫游者§f
+subtitles.threat.discovered=§6强化生物§f已记录下一个§c漫游者§f
 
 //guide_book json key
 gui.srpcotesia.guide_book.name=§e超生物学认知手册

--- a/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
@@ -5,16 +5,34 @@ lingering_potion.effect.antibodies=滞留型抗体药水
 tipped_arrow.effect.antibodies=抗体之箭
 
 effect.latched=§7栓锁
-splash_potion.effect.latched=喷溅型§7栓锁§f药水
-potion.effect.latched=§7栓锁§f药水
-lingering_potion.effect.latched=滞留型§7栓锁§f药水
-tipped_arrow.effect.latched=§7栓锁§f之箭
+splash_potion.effect.latched=喷溅型§7栓锁§r药水
+potion.effect.latched=§7栓锁§r药水
+lingering_potion.effect.latched=滞留型§7栓锁§r药水
+tipped_arrow.effect.latched=§7栓锁§r之箭
 
 effect.recuperation=§d恢复
-splash_potion.effect.recuperation=喷溅型§d恢复§f药水
-potion.effect.recuperation=§d恢复§f药水
-lingering_potion.effect.recuperation=喷溅型§d恢复§f药水
-tipped_arrow.effect.recuperation=§d恢复§f之箭
+splash_potion.effect.recuperation=喷溅型§d恢复§r药水
+potion.effect.recuperation=§d恢复§r药水
+lingering_potion.effect.recuperation=滞留型§d恢复§r药水
+tipped_arrow.effect.recuperation=§d恢复§r之箭
+
+effect.unkindling=§6阻燃
+splash_potion.effect.unkindling=喷溅型§6阻燃§r药水
+potion.effect.unkindling=§6阻燃§r药水
+lingering_potion.effect.unkindling=滞留型§6阻燃§r药水
+tipped_arrow.effect.unkindling=§6阻燃§r之箭
+
+effect.yielding=§6屈从
+splash_potion.effect.yielding=喷溅型§6清算§r药水
+potion.effect.yielding=§6清算§r药水
+lingering_potion.effect.yielding=滞留型§6清算§r药水
+tipped_arrow.effect.yielding=§6清算§r之箭
+
+effect.clotting=§4凝血
+splash_potion.effect.clotting=喷溅型§4凝血§r药水
+potion.effect.clotting=§4凝血§r药水
+lingering_potion.effect.clotting=滞留型§4凝血§r药水
+tipped_arrow.effect.clotting=§4凝血§r之箭
 
 effect.dazed=眩晕
 splash_potion.effect.dazed=喷溅型眩晕药水
@@ -48,10 +66,10 @@ lingering_potion.effect.watched=滞留型观测药水
 tipped_arrow.effect.watched=观测之箭
 
 effect.gravity=§b重力
-splash_potion.effect.gravity=喷溅型§b高重力§f药水
-potion.effect.gravity=§b高重力§f药水
-lingering_potion.effect.gravity=滞留型§b高重力§f药水
-tipped_arrow.effect.gravity=§b高重力§f之箭
+splash_potion.effect.gravity=喷溅型§b高重力§r药水
+potion.effect.gravity=§b高重力§r药水
+lingering_potion.effect.gravity=滞留型§b高重力§r药水
+tipped_arrow.effect.gravity=§b高重力§r之箭
 
 attribute.name.srpcotesia.meleeMinimumDamage=最低近战伤害
 attribute.name.srpcotesia.meleePercentDamage=最低近战伤害转换率
@@ -71,13 +89,69 @@ commands.srpcotesia.setbiomass.usage=/setbiomass <number> 或 /setbiomass <playe
 commands.srpcotesia.setbloom.usage=/setbiomass <number> 或 /setbiomass <player(s)> <number>
 commands.srpcotesia.togglenote.usage=/togglenote 或 /togglenote <player(s)>
 commands.srpcotesia.setKillC.usage=/setbiomass <number> 或 /setbiomass <player(s)> <number>
-commands.srpcotesia.ante.usage=/ante <set|add|subtract> <ticks> 或 /ante query
+commands.srpcotesia.ante.usage=/ante <set|add|subtract|setminimum> <value> 或 /ante <query|recalibrate>
 commands.srpcotesia.atimer.usage=/atimer <set|add|subtract> <ticks> 或 /atimer query
 commands.srpcotesia.adapt.usage=/adapt <parasite(s)> <source>
+commands.srpcotesia.assimilateplayer.usage=/assimilateplayer <player(s)> 或 /assimilateplayer
 commands.srpcotesia.dendritus.usage=/dendritus
+
+commands.srpcotesia.assimilateplayer.alreadyparasite=%s已经是寄生体了。
+commands.srpcotesia.assimilateplayer.possessing=%s已经夺舍了一个生物。
+commands.srpcotesia.assimilateplayer.dead=%s要么已经死亡，要么无实体。
+commands.srpcotesia.assimilateplayer.success=已成功给%s颁发了达尔文奖。
+
+commands.srpcotesia.srpcbounty.usage=/srpcbounty <list|clear|listtargets|cleartargets> 或 /srpcbounty <add|remove> <x> <y> <z> 或 /srpcbounty <addtarget|removetarget> <player or UUID>
+
+commands.srpcotesia.srpcbounty.disabled=悬赏目前已禁用。
+
+commands.srpcotesia.srpcbounty.list=在 x=%d，y=%d，z=%d 有一个活动中的悬赏
+commands.srpcotesia.srpcbounty.list.range=悬赏有 %d 格范围
+commands.srpcotesia.srpcbounty.list.terminal=悬赏范围已被设置为无限
+commands.srpcotesia.srpcbounty.list.none=这里没有活动中的悬赏。
+
+commands.srpcotesia.srpcbounty.clear=清除所有活动中的悬赏。方块本身可能仍然存在，但已失去效用。
+
+commands.srpcotesia.srpcbounty.add.inrange=位置与现有的位于 x=%d，y=%d，z=%d 的悬赏过于接近。
+commands.srpcotesia.srpcbounty.add.incorrectdim=悬赏无法被放置于这个维度。（%d）。
+commands.srpcotesia.srpcbounty.add.notloaded=如果已存在不可替换的方块，或者根本无法在此处放置方块，则悬赏无法放置于未加载的区块。
+commands.srpcotesia.srpcbounty.add.success=一个悬赏已成功放置于 x=%d，y=%d，z=%d。
+
+commands.srpcotesia.srpcbounty.remove=位于 x=%d，y=%d，z=%d 的悬赏已成功移除。该方块已失效。
+
+commands.srpcotesia.srpcbounty.remove.none=这里没有悬赏。
+
+commands.srpcotesia.srpcbounty.listtargets=目前已知的漫游者：
+commands.srpcotesia.srpcbounty.listtargets.uuid=玩家UUID：%s
+commands.srpcotesia.srpcbounty.listtargets.player=玩家名：%s
+
+commands.srpcotesia.srpcbounty.cleartargets=清除已知漫游者名录。
+
+commands.srpcotesia.srpcbounty.addtarget=成功将 %s 作为已知漫游者添加。
+commands.srpcotesia.srpcbounty.addtarget.fail=%s 已被标识为漫游者。
+commands.srpcotesia.srpcbounty.addtarget.totalfail=不存在符合标准的漫游者。
+
+commands.srpcotesia.srpcbounty.removetarget=成功将 %s 从已知漫游者名录中移除。
+commands.srpcotesia.srpcbounty.removetarget.fail=%s 并未标识为漫游者。
+commands.srpcotesia.srpcbounty.removetarget.totalfail=不存在符合标准的漫游者。
+
+
+
 commands.srpcotesia.srpcwell.usage=/srpcwell <get|clear|fix> <dimension id, optional> 或 /srpcwell <add|remove> <x> <z> <dimension id, optional>
 
+commands.srpcotesia.srpcwell.disabled=井口目前已禁用。
+
 commands.srpcotesia.srpcwell.empty=当前没有活动的井口。
+
+commands.srpcotesia.srpcwell.get=已在%s（维度 ID %d）激活一个x=%d，z=%d 生命值 %d 的井口。
+commands.srpcotesia.srpcwell.clear=已移除所有井口。
+commands.srpcotesia.srpcwell.clear.dim=已移除%s的所有井口。（维度 ID %d）
+commands.srpcotesia.srpcwell.add=井口已成功添加至x=%d，z=%d，%s（维度 ID %d）
+commands.srpcotesia.srpcwell.incorrectdim=无法在那一维度安置井口。
+commands.srpcotesia.srpcwell.toomany=各个维度存在的井口过多了。
+commands.srpcotesia.srpcwell.toomanydim=%s存在的井口过多了。（维度 ID %d）
+commands.srpcotesia.srpcwell.remove=已成功移除x=%d，z=%d，%s（维度 ID %d）的井口。
+commands.srpcotesia.srpcwell.remove.none=这里没有井口。
+commands.srpcotesia.srpcwell.nofix=所有井口都已生效，或根本没有井口。
 
 command.srpcotesia.srpmobcounts.top=========== 寄生体计数  ==========
 command.srpcotesia.srpmobcounts.info=这里有 %d 种不同的寄生实体。共计发现寄生体总数为 %d。
@@ -85,27 +159,21 @@ command.srpcotesia.srpmobcounts.displaying=显示 %d 最为频繁：
 command.srpcotesia.srpmobcounts.class=%s：%d
 command.srpcotesia.srpmobcounts.name=%s（%s）：%d
 
-commands.srpcotesia.srpcwell.get=已在%s（维度 ID %d）激活一个x=%d ，z=%d 生命值 %d 的井口。
-commands.srpcotesia.srpcwell.clear=已移除所有井口。
-commands.srpcotesia.srpcwell.clear.dim=已移除%s的所有井口。（维度 ID %d）
-commands.srpcotesia.srpcwell.add=井口已成功添加至x=%d，z=%d，%s（维度 ID %d）
-commands.srpcotesia.srpcwell.remove=已成功移除x=%d，z=%d，%s（维度 ID %d）的井口。
-commands.srpcotesia.srpcwell.remove.none=这里没有井口。
-commands.srpcotesia.srpcwell.nofix=所有井口都已生效，或根本没有井口。
-
 commands.srpcotesia.dendritus.active=一个已激活的 %s 阶树突体位于x=%d，y=%d，z=%d，其作用范围为 %d 格 
-commands.srpcotesia.dendritus.inactive=一个已惰化的 %s 阶树突体，位于x=%d，y=%d，z=%d，其作用范围为 %d 格 
+commands.srpcotesia.dendritus.inactive=一个已惰化的 %s 阶树突体位于x=%d，y=%d，z=%d，其作用范围为 %d 格 
 commands.srpcotesia.dendritus.noneactive=没有已激活的树突体。
 
 commands.srpcotesia.atimer.disabled=末日计时已关闭
 commands.srpcotesia.atimer.query=离末日还剩 %d 刻。
 
 commands.srpcotesia.ante.disabled=适应因子已被禁用。
-commands.srpcotesia.ante.query=目前的适应因子为 %d。
+commands.srpcotesia.ante.query=目前的适应因子为 %d。目前的最低适应因子为 %d。
+commands.srpcotesia.ante.recalibrate=适应因子已重新校准。
 
 death.attack.out_of_time=%1$s耗尽了时间。
 death.attack.gave_up=%1$s抛弃了他的躯壳。
 death.attack.gravity_crushing=%1$s已然扁得不能再扁。
+death.attack.auricFire=%1$s被金焰电离了。
 
 commands.srpcotesia.adapt.adapted=强制 %d 个实体适应“%s”
 commands.srpcotesia.adapt.cant=发现 %d 个无法适应的实体
@@ -113,12 +181,12 @@ commands.srpcotesia.adapt.cant=发现 %d 个无法适应的实体
 commands.srpcotesia.setbloom.positive=值必须为正数！
 commands.srpcotesia.setKillC.between=值必须在 0 到 %d 之间！
 
-commands.srpcotesia.toggleparasite.success=已成功将寄生体状态设置为 %s。
-commands.srpcotesia.setbiomass.success=已成功将生物质设置为 %d。
-commands.srpcotesia.setbloom.success=已成功将进化阶段设置为 %d。
-commands.srpcotesia.togglenote.success=已成功将可靠的信函获取状态由 %s 切换至 %s。
-commands.srpcotesia.setKillC.success=成功将击杀计数设置为 %d。
-commands.srpcotesia.ante.success=成功将适应因子设置为 %d。
+commands.srpcotesia.toggleparasite.success=已成功将寄生体状态设置给 %s。
+commands.srpcotesia.setbiomass.success=已成功将该生物质状态设置给 %d。
+commands.srpcotesia.setbloom.success=已成功将该进化阶段设置给 %d。
+commands.srpcotesia.togglenote.success=已成功将 %s 可靠的信函获取状态切换至 %s。
+commands.srpcotesia.setKillC.success=成功将击杀计数设置给 %d。
+commands.srpcotesia.ante.success=成功将适应因子设置为 %d。目前的最低适应因子为 %d。
 commands.srpcotesia.atimer.success=已成功将末日计时设置为 %d。
 
 key.srpcotesia.togglehide=伪装/取消伪装
@@ -134,7 +202,10 @@ key.categories.srpcotesia=SRP：寄生蜂
 
 entity.srpcotesia.latch.name=寄染索
 entity.srpcotesia.factory.name=寄生巢穴
-  
+entity.srpcotesia.mote.name=微尘
+
+tooltip.srpcotesia.item.parasitedrop=可用任意一种剑右键已放置的 %s §7寄生巢穴获取。
+
 item.srpcotesia.factory.name=寄生巢穴
 tooltip.srpcotesia.factory.unbound=未绑定
 tooltip.srpcotesia.factory.nonparasite=§f这东西会带来麻烦。
@@ -147,7 +218,7 @@ overlay.srpcotesia.insert=%s添加生物质
 overlay.srpcotesia.takeout=%s取出生物质
 overlay.srpcotesia.nocolony=缺少聚生地
 overlay.srpcotesia.seconds=%d 秒
-overlay.srpcotesia.factoryblocked=无法生成
+overlay.srpcotesia.factoryblocked=无法生成该寄生体
 overlay.srpcotesia.biomass=%d/%d 生物质
 overlay.srpcotesia.biomass.cost=%d/%d 生物质，消耗：%d 生物质
 overlay.srpcotesia.cost=需要花费：%d 生物质
@@ -163,6 +234,7 @@ overlay.srpcotesia.dispatcher.retrieve=按下%s取回存储的寄生体
 
 overlay.srpcotesia.factory.dissolve=按下%s溶解寄生体
 
+overlay.srpcotesia.catchingup=点数获取不与当前世界绑定！
 
 item.srpcotesia.brew_sac.name=酿造囊
 tooltip.srpcotesia.brew_sac.judgemental=它不属于你。
@@ -177,13 +249,15 @@ tooltip.srpcotesia.reagent.via=§f当放入§b渗透活化器§f时:
 tooltip.srpcotesia.reagent.adds=§f添加药水效果：%s
 tooltip.srpcotesia.reagent.damage=§f将药水基础伤害更改为 %f
 tooltip.srpcotesia.reagent.intensifier=§f增加酿造系数
+tooltip.srpcotesia.reagent.incompatible=§f与%s§r不兼容
 
 tooltip.srpcotesia.pointmulti.global=全局进化点数增益 +%s%%
 tooltip.srpcotesia.pointmulti.singular=进化点数增益 +%s%%
 tooltip.srpcotesia.pointmultidrain=每秒消耗 %d 经验
 
 brew.srpcotesia.potion.name=施加%s
-brew.srpcotesia.emptyPotion.name=药水不足
+brew.srpcotesia.potion.name.max=施加%s§r，最大等级为 %s
+brew.srpcotesia.emptyPotion.name=无药水效果
 brew.srpcotesia.parasitepotion.desc=向寄生体添加此效果。
 brew.srpcotesia.enemypotion.desc=向非寄生体添加此效果。
 brew.srpcotesia.harm.name=损伤
@@ -196,6 +270,19 @@ brew.srpcotesia.explosion.name=爆炸
 brew.srpcotesia.explosion.desc=命中后产生不破坏地形的爆炸。
 brew.srpcotesia.turn.name=转化
 brew.srpcotesia.turn.desc=在生物足够虚弱时同化该生物。如果演化阶段允许的话，会产生狂化种。
+brew.srpcotesia.repeat.name=重复
+brew.srpcotesia.repeat.desc=再次施加前述的效果。
+brew.srpcotesia.rally.name=集结
+brew.srpcotesia.rally.desc=将远处的某只寄生体传送至酿造囊的命中位置。
+
+item.srpcotesia.itemenhance.name=§6强化之杖
+tooltip.srpcotesia.itemenhance=指向某个生物（或将之对某个生物使用），以§6强化§r生物
+message.srpcotesia.enhancedmobsdisabled=§6强化生物§f目前已被禁用。
+
+message.srpcotesia.itemenhance.succeed=§6生物已强化。
+message.srpcotesia.itemenhance.repeat=§6该生物已被强化。
+message.srpcotesia.itemenhance.fail=§6该生物无法被强化，或该生物无法在此强化。
+message.srpcotesia.itemenhance.parasite=§6这根本不可能办到。
 
 item.srpcotesia.scorned_pearl.name=§c蔑视珍珠
 tooltip.srpcotesia.scorned_pearl.parasite1=§c极其令人反感。
@@ -210,13 +297,54 @@ message.srpcotesia.scorned_pearl.dark=你必须在完全黑暗的环境下。
 message.srpcotesia.scorned_pearl.cooldown=它在冷却时间中无法生效。
 message.srpcotesia.scorned_pearl.toolow=这有些过头了。
 
+item.srpcotesia.remnant.name=遗骸
+tooltip.srpcotesia.remnant=§f巴掌大的圆盘，来自§6被强化的%s§f。
+tooltip.srpcotesia.remnant.unbound=§f在实体上使用它便可制作该实体的§d遗骸§f。§f任何涉及此物品的配方都表示可以用任意一种§d遗骸§f替换。
+tooltip.srpcotesia.remnant1=§d遗骸§f会由遭寄生体击杀的§6强化生物§f掉落，不过，§c漫游者§f必须直接参与这一过程。
+tooltip.srpcotesia.remnant.notyet=§6强化生物§f尚未强大到掉落遗骸。
+tooltip.srpcotesia.remnant2=§f被动生物不会掉落该物品。
+tooltip.srpcotesia.remnant3=§f5 个不同的遗骸可用于制作§b蚀刻机§f上的§6芯片节段§f。
+
+item.srpcotesia.chip_fragment.name=§6芯片节段
+tooltip.srpcotesia.chip_fragment=§f一块小小的电路板。它小巧玲珑，可以安全地手持。
+tooltip.srpcotesia.chip_fragment1=§6某些更重要之物§f的一小部分。
+tooltip.srpcotesia.chip_fragment2=§f使用 5 个不同§d遗骸§f制作，用在§b蚀刻机§f上。
+tooltip.srpcotesia.chip_fragment3=§4用你的知觉来揭露它。其他同胞对此一无所知，尽管这并非因为它们的无能。
+
+item.srpcotesia.callous_chip.name=§6厚实芯片
+tooltip.srpcotesia.callous_chip=§f异常发热的不稳定芯片。
+tooltip.srpcotesia.callous_chip1=§6某些更危险之物§f的一小部分。
+tooltip.srpcotesia.callous_chip2=§c我需要它来进一步合成物品。
+tooltip.srpcotesia.callous_chip3=§4说服其他同胞生产这些东西一直徒劳无功。我们只能靠自己了。
+
+message.srpcotesia.item.yielding=§b如果物品栏中持有该物品，会削弱你的能力。
+
+item.srpcotesia.signal_jammer.name=§6信号干扰器
+tooltip.srpcotesia.signal_jammer1=§f使附近的强化生物在数秒内无法造成暴击。
+tooltip.srpcotesia.signal_jammer2=§6> 不要去干预你无法理解的事物。
+tooltip.srpcotesia.signal_jammer3=§6  这是你的同类自找的。
+message.srpcotesia.signal_jammer.waste=§f范围内没有§6强化生物§f。
+
+
+item.srpcotesia.bloodstained_saddle.name=§b染血之鞍
+tooltip.srpcotesia.bloodstained_saddle.fake=§f一个遭内部感染撕裂的鞍座。
+tooltip.srpcotesia.bloodstained_saddle1=§f可以放置在某些寄生体上，允许它们被骑乘。
+tooltip.srpcotesia.bloodstained_saddle2=§f这一物品会被消耗掉。将该寄生体转化为生物质（或该寄生体死亡）时会恢复成鞍。
+tooltip.srpcotesia.bloodstained_saddle3=§f只对你曾参与创造的寄生体有效。
 
 item.srpcotesia.macabre_pearl.name=§b血肉珍珠
 tooltip.srpcotesia.macabre_pearl.fake=§f一枚珍珠，其晦暗一如你的将来。
 tooltip.srpcotesia.macabre_pearl1=§f令寄生体服从你，使你能更加便利地驱使它们。
 tooltip.srpcotesia.macabre_pearl2=§f对寄生体使用以切换其行动模式。
 tooltip.srpcotesia.macabre_pearl3=§f只对你曾参与创造的寄生体有效。
-tooltip.srpcotesia.macabre_pearl4=§4越多越好。
+tooltip.srpcotesia.macabre_pearl4=§4总得有什么罩着你。你最后总会做些傻事。
+
+item.srpcotesia.itemdismiss.name=§a溶解之杖
+tooltip.srpcotesia.itemdismiss1=指向某个寄生体（或将之对某个寄生体使用），将之§a清除
+tooltip.srpcotesia.itemdismiss.fake=不过，你必须处于创造模式才能将它强制溶解。
+tooltip.srpcotesia.itemdismiss2=§4仅有你我。
+
+message.srpcotesia.itemdismiss.unworthy=§f它似乎不大乐意。
 
 item.srpcotesia.factory_drop.name=§e巢穴内脏
 tooltip.srpcotesia.factory_drop1=§f从§e寄生巢穴§f那获得的凝胶状肉团。它已经支离破碎。
@@ -225,6 +353,12 @@ tooltip.srpcotesia.factory_drop3=§4掩盖你的行踪会更明智。销毁它�
 
 item.srpcotesia.mortifying_tentacle.name=§2坏死卷须
 tooltip.srpcotesia.mortifying_tentacle=§f一条§2卓越种§f寄生体的小型变体触须。
+
+item.srpcotesia.bogle_charge.name=§2怖怪体爆弹
+tooltip.srpcotesia.bogle_charge=§f一个§2怖怪体§f高爆弹的小型变体。
+
+item.srpcotesia.virulent_breath.name=§a病毒吐息
+tooltip.srpcotesia.virulent_breath=§f一瓶被§a病毒§f侵染的龙息。
 
 item.srpcotesia.putrid_unit.name=§c腐臭单元
 tooltip.srpcotesia.putrid_unit1=§f一簇杂乱无章的神经组织，出自一只§c狂化种§f寄生体。
@@ -240,6 +374,7 @@ tooltip.srpcotesia.item.notdisruptor=§f不干扰§1相移§f
 tooltip.srpcotesia.factory.deterrent=受到鼓舞
 tooltip.srpcotesia.factory.bound=绑定%s
 tooltip.srpcotesia.factory.tier=等级：%d
+tooltip.srpcotesia.factory.cannotproduce=无法生产该寄生体，仅能用于制作掉落物。
 tooltip.srpcotesia.factory.created=§c可按%s键创造
 tooltip.srpcotesia.factory.shift=按住 LSHIFT 查看更多信息
 tooltip.srpcotesia.factory.desc1=寄生巢穴是其他寄生体身上产下的功能性寄生体。
@@ -261,8 +396,15 @@ tooltip.srpcotesia.masticator1=§f喷出有毒的瘴气。瘴气在演化 %d 阶
 tooltip.srpcotesia.masticator2=§f需要§a腥臭“滤毒罐”§f运作。
 tooltip.srpcotesia.masticator3=§4一件由你的记忆和我们自己的记忆共同缔造的艺术品。
 tooltip.srpcotesia.masticator4=§4正如你的直觉所述，最初的设计是有缺陷的。火在此百无一用。
+
+item.srpcotesia.consecrator.name=§4祝圣瘴气枪
+tooltip.srpcotesia.consecrator1=§f喷出恐怖的瘴气。瘴气可侵袭方块，且演化 %d 阶时，如果在§4节点§f范围内将制造群系，并增加§a进化点数§f。
+tooltip.srpcotesia.consecrator2=§f需要§a腥臭“滤毒罐”§f运作。
+tooltip.srpcotesia.consecrator3=§4从海到海，骨肉相连。
+tooltip.srpcotesia.consecrator4=§4令大地歌唱。
 tooltip.srpcotesia.masticator.notempty=§a里面还剩一点汁液
 tooltip.srpcotesia.masticator.notparasite=§f一只类似§a召唤柱§f的手持式畸变体。
+tooltip.srpcotesia.consecrator.notparasite=§f一只类似§aIV 阶召唤柱§f的手持式畸变体。
 
 item.srpcotesia.fetid_canister.name=§a腥臭“滤毒罐”
 tooltip.srpcotesia.fetid_canister1=§f由寄生体各部分组成的致密茧状物，因新的目的结合在一起。
@@ -293,6 +435,12 @@ tooltip.srpcotesia.well_divining_rod1=§f朝最近的§6井口§f方向发射火
 tooltip.srpcotesia.well_divining_rod2=§f如果它在一个不同的维度，则会提及维度名称。
 tooltip.srpcotesia.well_divining_rod3=§6> 算算你的天数。
 
+item.srpcotesia.well_magnet.name=§6井口磁铁
+tooltip.srpcotesia.well_magnet1=§f将该维度在 %s 格范围内最近的§6井口§f传送至使用者。
+tooltip.srpcotesia.well_magnet2=§6> 某处有个岩浆池等着你呢。帮我们个忙。
+tooltip.srpcotesia.well_magnet3=§c我想我把它惹火了
+message.srpcotesia.well_magnet.waste=将仅有 %d 格距离的§6井口§f传送来也太浪费了。
+message.srpcotesia.well_magnet.moved=一个§6井口§f已被移动。
 
 message.srpcotesia.nowell=当前没有活动的§6井口§f。
 message.srpcotesia.nowellrange=附近没有§6井口§f。
@@ -305,7 +453,7 @@ message.srpcotesia.well.created=一个§6井口§f已经形成。
 message.srpcotesia.well.created.multiple=数个§6井口§f已经形成。
 message.srpcotesia.well.destroyed=一个位于 %s 的§6井口§f已被摧毁！
 message.srpcotesia.well.damaged=§6井口§f现在还有 %d 生命值。
-message.srpcotesia.well.fix=由于处于无效位置，一个§6井口§f已移至 x=0，z=0 位置。
+message.srpcotesia.well.fix=由于处于无效位置，一个§6井口§f已移至 x=0，z=0。
 message.srpcotesia.well.fixdim=由于处于无效维度，一个§6井口§f已移至 %s。
 message.srpcotesia.well.fixclear=§6井口§f已无法在任何维度形成。因此，它们都已被清除。
 message.srpcotesia.well.fixprevent=§6井口§f已无法在任何维度形成。
@@ -320,16 +468,35 @@ tooltip.srpcotesia.vagrant_divining_rod2=§f当§c漫游者§f在别的维度时
 tooltip.srpcotesia.vagrant_divining_rod3=§c这似乎不大公平。
 tooltip.srpcotesia.vagrant_divining_rod4=§4立刻把它销毁。
 
-message.srpcotesia.item.disabled=§f该物品已被禁用。
+message.srpcotesia.item.disabled=§c该物品已被禁用。
 message.srpcotesia.novagrants=这个维度没有活动中的§c漫游者§f。
 message.srpcotesia.trackedvagrant=你感到无所不在的恐惧……
 
 tile.srpcotesia.gloom_torch.name=§e幽暗火把
 tooltip.srpcotesia.gloom_torch=§4不错的改进。
 
-
 tile.srpcotesia.beckonh.name=§a召唤柱先兆体
 tooltip.srpcotesia.beckonh=§f可以用来创造一根召唤柱。互动以给予生物质。 
+
+tooltip.srpcotesia.dispatchern1=§f可以用来创造一只§c调度柱§f。互动以给予生物质。 
+tooltip.srpcotesia.dispatchern2=§f寄生体在杀敌数量足够时，便有概率放置一个调度柱胞窝。
+tooltip.srpcotesia.dispatchern3=§f也可以通过§c胞窝累聚体§f制造。
+
+tooltip.srpcotesia.evclock1=§f显示当前全局累计的演化点数，也包括当前的演化阶段。
+tooltip.srpcotesia.evclock2=§f同时会读出当前演化冷却时间，如果这会有的话。
+
+
+
+item.srpcotesia.electroreceptor.name=§e电感受器
+tooltip.srpcotesia.electroreceptor=§f可以用来读取寄生体的§c击杀计数§f。
+tooltip.srpcotesia.electroreceptor.bounty=§f如果用在§6强化生物§f身上，它将显示某个§6悬赏§f的部分坐标。可能需要多次使用。
+
+message.srpcotesia.electroreceptor=%s已有 %s 击杀计数。
+message.srpcotesia.electroreceptor.player=%s拥有 %s 生物质，且已有相当于 %s 击杀计数的贡献点数。
+message.srpcotesia.electroreceptor.bounty.x=X=%d
+message.srpcotesia.electroreceptor.bounty.y=Y=%d
+message.srpcotesia.electroreceptor.bounty.z=Z=%d
+
 
 message.srpcotesia.nearbyvenkrol=附近已经有一根召唤柱了。
 message.srpcotesia.notready=你还没有准备好。还不行。
@@ -351,7 +518,7 @@ tooltip.srpcotesia.parasitelightsource2=§f使相邻光源成为可接受的光�
 
 tile.srpcotesia.reclamation_table.name=§b回收台
 tooltip.srpcotesia.reclamation_table.enemy=§f带着不自然寒意的方块，散发出令人焦虑的氛围。
-tooltip.srpcotesia.reclamation_table1=§f用以将诸多§c与寄生体相关§f的物品送回 §8§kThe Source§f。你会获得§a经验值§f作为回报。
+tooltip.srpcotesia.reclamation_table1=§f用以将诸多§c与寄生体相关§f的物品送回 §8§kThe Source§f。你会得到§a经验值§f作为回报。
 tooltip.srpcotesia.reclamation_table2=§f与这一方块交互，将掉落于其上方的物品送出。
 tooltip.srpcotesia.reclamation_table3=§4我们会给它们一个新归处。
 
@@ -370,10 +537,25 @@ tooltip.srpcotesia.dendritus2=§f增强一个§c调度柱§f以将§1相移§f�
 tooltip.srpcotesia.dendritus3=§f必须按%s将它提供给调度柱。
 tooltip.srpcotesia.dendritus4=§f如果手动放置，则可以按%s激活它。
 
+tile.srpcotesia.bounty.name=§6悬赏
+tooltip.srpcotesia.bounty1=§f强化生物会放置一个§6悬赏§f记录这个区域已知的§c漫游者§f。所有在同一维度的§6悬赏§f都将共享数据。
+tooltip.srpcotesia.bounty2=§f所有生成在范围内的§6强化生物§f都将共享这一知识，其生成率也将提高。
+
+tooltip.srpcotesia.bountydisabled=§6悬赏§f目前已被禁用。
+
+message.srpcotesia.bounty.created=§f一个§6悬赏§f已被放置。
+message.srpcotesia.bounty.notify=§f一个§6悬赏§f已进行通报。
 
 tile.srpcotesia.osmosis.name=§b渗透活化器
 tooltip.srpcotesia.osmosis1=§f根据放入的§9反应物§f对§9酿造囊§f进行改造。用酿造囊或§9反应物§f右键点击放入。
-tooltip.srpcotesia.osmosis2=§f提示框内会显示被活化后§9反应物§f的效果。
+tooltip.srpcotesia.osmosis2=§f工具提示栏内会显示被活化后§9反应物§f的效果。
+
+tile.srpcotesia.lithograph.name=§b蚀刻机
+tooltip.srpcotesia.lithograph1=§f从§d遗骸§f提取数据用于生产§6芯片节段§f。拿着§d遗骸§f鼠标左击将之放入。
+tooltip.srpcotesia.lithograph2=§f当它包含了 5 份§d遗骸§f，它将开始数据提取。
+
+tile.srpcotesia.lithograph.conflict=这一遗骸已被储存。
+tile.srpcotesia.lithograph.full=已没有空槽位。
 
 item.srpcotesia.booster_si.name=§6阶段增幅器
 item.srpcotesia.booster_sii.name=§6受控的阶段增幅器
@@ -390,12 +572,42 @@ tooltip.srpcotesia.soulless_core1=§f一个已经失活的§e活体核心§f。
 tooltip.srpcotesia.soulless_core2=§f可以代替猎杀其他寄生体的方式获取其他种类的核心——如果有的话。持有时与所需的寄生体交互。
 tooltip.srpcotesia.soulless_core3=§4一种达到目的的手段。
 
+tooltip.srpcotesia.vengence_core=§c我应该对§6适应种§c寄生体使用§e无魂核心§c，而无需杀戮。
+tooltip.srpcotesia.wrathful_core=§c我应该对§e纯粹种§c寄生体使用§e无魂核心§c，而无需杀戮。
+
+
+item.srpcotesia.nidus_accumulator.name=§c胞窝累聚体
+tooltip.srpcotesia.nidus_accumulator=§f一块类似§c调度柱胞窝§f的肿胀痂皮。
+tooltip.srpcotesia.nidus_accumulator1=§f持有者每次击杀生物，都会收集一个击杀点数。必须放置于快捷栏它才会收集击杀点数。
+tooltip.srpcotesia.nidus_accumulator2=§f如果它收集到了足够的击杀点数，它将会转化成一个§c调度柱胞窝§f。
+tooltip.srpcotesia.nidus_accumulator3=§f目前的击杀计数：%d
+tooltip.srpcotesia.nidus_accumulator4=§4创造
+
+item.srpcotesia.pristine_matter.name=§a原生物质
+tooltip.srpcotesia.pristine_matter=§f从§aIII/IV 阶召唤柱§f上收集到的一小团发光的肉。用于合成。
+
+item.srpcotesia.pact.name=§a契约
+tooltip.srpcotesia.pact=§f一份来历不明的寄染卷轴。
+tooltip.srpcotesia.pact1=§f可用于在一个已加载的区块内§4遣散所有目前活动中的寄生体§f，不包括§a连结种§f。在全局演化阶段冷却时无法生效。也无法对维持某些生成结构的寄生体生效。
+tooltip.srpcotesia.pact2=§f如果对除§e寄生巢穴§f以外的§a连结种§f使用，它也会遣散所有这一阶段或者低于该阶段的§a连结种§f。
+tooltip.srpcotesia.pact3=§f如果对你所创造的寄生体使用，不会被刷新消失的寄生体也会被遣散。这同样不包括§e寄生巢穴§f，并与前者同时发生。
+tooltip.srpcotesia.pact4=§f一个§a气味腺体§f会按照你所遣散的最高级别的寄生体生成（扎根于地面或由你创造的东西除外）。潜行可以避免这种情况发生，物品也不会被消耗。
+tooltip.srpcotesia.pact5=§4证明这一概念的合理性是项艰巨的任务。
+
+message.srpcotesia.pact.empty=这里没有任何寄生体可供遣散。
+message.srpcotesia.pact.emptyscentremoved=§c这里没有任何寄生体可供填补气味因子，但寄生体也已移除。
+
+item.srpcotesia.scent_gland.name=§a气味腺体
+tooltip.srpcotesia.scent_gland=§f味道像是胡椒粉或荧光墨囊。很难闻。
+tooltip.srpcotesia.scent_gland1=§c闻起来像是武器。
+tooltip.srpcotesia.scent_gland2=§f在演化阶段不足以支持气味因子和统一意志存在时不生效。
+tooltip.srpcotesia.scent_gland3=§f使用它攻击实体时，将召唤下列寄生体：
+tooltip.srpcotesia.scent_gland.empty=§f没有任何寄生体记录在内。使用§a契约§f创建一个合适的腺体。
+
 item.srpcotesia.moldered_segments.name=§e腐化节段
 tooltip.srpcotesia.moldered_segments1=§f一对废弃的肉片。它似乎毫无用处。
 tooltip.srpcotesia.moldered_segments2=§c它需要§a I 阶召唤柱§c。
 tooltip.srpcotesia.moldered_segments3=§4一份馈赠，需要时间来发酵。你会对此做些什么，我们拭目以待。
-
-
 
 item.srpcotesia.trojan_note.name=可靠的信函
 tooltip.srpcotesia.trojan_note=加急
@@ -442,11 +654,12 @@ message.srpcotesia.alreadyinfected=一事不二罚。
 message.srpcotesia.notefailphase=它“啪”地一下关上了。它们一定是觉得这有些多余了。
 message.srpcotesia.notefaildim=它纹丝不动。在这个维度上它似乎变弱了。
 message.srpcotesia.notefailday=它纹丝不动。也许可以天黑后再试试？
+message.srpcotesia.notefailpossessing=信函显得有些困惑。你必须得获得你原本的躯壳。
 message.srpcotesia.notefailmoon=它纹丝不动。也许月相不对。
 message.srpcotesia.notefail=它纹丝不动。也许可以过会再试？
-message.srpcotesia.rpl=你突然感到十分空虚……
-message.srpcotesia.rpl.burning=灼热的疼痛炙烤着你的太阳穴……
-message.srpcotesia.well.subtract=远方的威胁日益强大……
+#message.srpcotesia.rpl=你突然感到十分空虚……
+#message.srpcotesia.rpl.burning=炙热的疼痛炙烤着你的太阳穴……
+message.srpcotesia.well.subtract=一处§6井口§f已经偷取了点数。
 
 message.srpcotesia.addpoints=成功增加 %d 进化点数！
 message.srpcotesia.evocooldown=目前处于冷却阶段，无法进化。
@@ -466,6 +679,8 @@ message.dendritus.inrange=在 %d，%d，%d 已有一个树突体
 
 message.srpcotesia.following=这只寄生体正跟随你。
 message.srpcotesia.notfollowing=这只寄生体已不再跟随你。
+message.srpcotesia.macabre_pearl.nexus=这只寄生体是属于你，但它没法跟随你。
+message.srpcotesia.saddled=这只寄生体已被置鞍。
 message.srpcotesia.didntmake=你并未创造它。
 
 message.srpcotesia.masticator.empty=你需要腥臭“滤毒罐”使其运转。
@@ -498,6 +713,10 @@ gui.jei.category.srpcotesia.factory.tierabove=等级 %d+
 gui.jei.category.srpcotesia.factory.pts=§4+%d 进化点数
 gui.jei.category.srpcotesia.factory=§4巢穴交易
 gui.jei.category.srpcotesia.parasite_transmute=§c寄生体转变
+gui.jei.category.srpcotesia.lithography=§b蚀刻
+gui.jei.category.srpcotesia.lithography.warning1=此处的显示的配方只是示例，并非必须。
+gui.jei.category.srpcotesia.lithography.warning2=材料顺序并不重要。任何一组独特的 5 个遗骸都可以。
+
 gui.jei.category.srpcotesia.osmosis=§b渗透酿造
 gui.jei.category.srpcotesia.reclamation=§b回收
 gui.jei.category.srpcotesia.reclamation.xp=§4+%d XP
@@ -510,6 +729,9 @@ enchantment.srpcotesia.fluidity.desc=§f减少巢穴产生寄生体所需的时�
 
 enchantment.srpcotesia.dense_tissue=§b致密组织
 enchantment.srpcotesia.dense_tissue.desc=§f令这个巢穴生成的寄生体拥有更高的血量上限。
+
+enchantment.srpcotesia.flaying=§5剥离
+enchantment.srpcotesia.flaying.desc=§f令这个巢穴生成的寄生体拥有更高的攻击力。
 
 enchantment.srpcotesia.cunning=§e狡诈
 enchantment.srpcotesia.cunning.desc=§f增加该巢穴产生寄生体所能造成的最低伤害。
@@ -577,7 +799,25 @@ tooltip.srpcotesia.guide_book.flavor2=§4这本书非常不对劲。它提到了
 
 tooltip.srpcotesia.guide_book.disabled=安装帕秋莉手册来使用这个物品吧！
 
+message.srpcotesia.infect=你成功地感染了一个生物。（+%d）
+
+message.srpcotesia.hyperarmor=我需要比这更狠地打击他们！
+message.srpcotesia.defense=继续攻击。还剩 %d 防御值。
+message.srpcotesia.nodefense=继续攻击。
+#message.srpcotesia.catchup=The points I'm getting are of no substance, since there's an Evolution Cooldown.
+
+message.srpcotesia.dissolution.possess=它还未成型。
+message.srpcotesia.dissolution.nothing=它尚未生效。
+message.srpcotesia.dissolution.possessing=它已经为我们腾出了空间。心怀感激吧。
+
+message.srpcotesia.bounty.intervention=有什么东西在跟着你。
+
+
+subtitles.threat.well=§6井口§f已形成
+subtitles.threat.bounty=§6悬赏§f已放置
+subtitles.threat.discovered=§6强化生物§f记录下了一只§c漫游者§f
+
 //guide_book json key
 gui.srpcotesia.guide_book.name=§e超生物学认知手册
-gui.srpcotesia.guide_book.landingtext=关于寄生体及其能力分类的百科全书，有备而无患。$(br2)$(c)如果一本书90%的页面都被撕了下来，那么它肯定没那么好用了。这本书就是如此，看起来更像一个活页夹，而非正儿八经的书。$(br)当然，这不影响我往上面添加自己的内容。
+gui.srpcotesia.guide_book.landingtext=关于寄生体及其能力分类的百科全书，有备而无患。$(br2)$(#630000)如果一本书90%%的页面都被撕了下来，那么它肯定没那么好用了。这本书就是如此，看起来更像一个活页夹，而非正儿八经的书。$(br)当然，这不影响我往上面添加自己的内容。
 gui.srpcotesia.guide_book.subtitle=第八版

--- a/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
@@ -591,7 +591,7 @@ tooltip.srpcotesia.pact=§f一份来历不明的寄染卷轴。
 tooltip.srpcotesia.pact1=§f可用于在已加载的区块内§4遣散除§a连结种§4以外所有正在活动中的寄生体§f。在全局演化阶段冷却时该物品无法生效。且该物品也无法对正在维持某些结构的寄生体生效。
 tooltip.srpcotesia.pact2=§f如果对除§e寄生巢穴§f以外的§a连结种§f使用该物品，它也会遣散所有这一阶段或者低于该阶段的§a连结种§f。
 tooltip.srpcotesia.pact3=§f如果对你所创造的寄生体使用该物品，不会自然消失的寄生体也会被遣散。这同样不包括§e寄生巢穴§f，而前述的遣散限制同样会生效。
-tooltip.srpcotesia.pact4=§f此后，一份§a循迹腺体§f将会生成，它会记录下你所遣散的最高级别的寄生体（扎根于地面或由你创造的寄生体除外）。潜行可以避免此事发生，过程中物品也不会被消耗。
+tooltip.srpcotesia.pact4=§f一个§a循迹腺体§f会基于被遣散的最高级别寄生体而生成（扎根于地面或由你创造的寄生体除外）。潜行可以避免生成，过程中不会消耗物品。
 tooltip.srpcotesia.pact5=§4证明这一概念的合理性是项艰巨的任务。
 
 message.srpcotesia.pact.empty=这里没有任何寄生体可供遣散。

--- a/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
@@ -438,7 +438,7 @@ tooltip.srpcotesia.well_divining_rod3=§6> 算算你的天数。
 
 item.srpcotesia.well_magnet.name=§6井口磁铁
 tooltip.srpcotesia.well_magnet1=§f将该维度在 %s 格范围内最近的§6井口§f传送至使用者。
-tooltip.srpcotesia.well_magnet2=§6> 某处有个岩浆池等着你呢。帮我们个忙。
+tooltip.srpcotesia.well_magnet2=§6> 某处有个熔岩池等着你呢。帮我们个忙。
 tooltip.srpcotesia.well_magnet3=§c我想我把它惹毛了
 message.srpcotesia.well_magnet.waste=将仅有 %d 格距离的§6井口§f传送来也太浪费了。
 message.srpcotesia.well_magnet.moved=一个§6井口§f已被移动。

--- a/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
@@ -182,10 +182,10 @@ commands.srpcotesia.setbloom.positive=值必须为正数！
 commands.srpcotesia.setKillC.between=值必须在 0 到 %d 之间！
 
 commands.srpcotesia.toggleparasite.success=已成功将 %s 的寄生体状态设置为 %s。
-commands.srpcotesia.setbiomass.success=已成功将该生物质状态设置给 %d。
-commands.srpcotesia.setbloom.success=已成功将该进化阶段设置给 %d。
+commands.srpcotesia.setbiomass.success=已成功将 %s 的生物质状态设置为 %d。
+commands.srpcotesia.setbloom.success=已成功将将 %s 的进化阶段设置为 %d。
 commands.srpcotesia.togglenote.success=已成功将 %s 可靠的信函获取状态切换至 %s。
-commands.srpcotesia.setKillC.success=成功将击杀计数设置给 %d。
+commands.srpcotesia.setKillC.success=成功将 %s 的击杀计数设置为 %d。
 commands.srpcotesia.ante.success=成功将适应因子设置为 %d。目前的最低适应因子为 %d。
 commands.srpcotesia.atimer.success=已成功将末日计时设置为 %d。
 
@@ -273,7 +273,7 @@ brew.srpcotesia.turn.desc=在生物足够虚弱时同化该生物。如果演化
 brew.srpcotesia.repeat.name=重复
 brew.srpcotesia.repeat.desc=再次施加前述的效果。
 brew.srpcotesia.rally.name=集结
-brew.srpcotesia.rally.desc=将远处的某只寄生体传送至酿造囊的受击位置。
+brew.srpcotesia.rally.desc=将远处的某只寄生体传送至酿造囊的击中位置。
 
 item.srpcotesia.itemenhance.name=§6强化之杖
 tooltip.srpcotesia.itemenhance=指向某个生物（或将之对某个生物使用），以§6强化§r生物
@@ -392,13 +392,13 @@ tooltip.srpcotesia.factory.desc12=如果这个巢穴受到鼓舞，它将被动�
 tooltip.srpcotesia.factory.desc13=可以在主配置的客户端设置中禁用此教程。
 
 item.srpcotesia.masticator.name=§a瘴气均质枪
-tooltip.srpcotesia.masticator1=§f喷出有毒的瘴气。瘴气在演化 %d 阶时可侵袭方块，并增加§a进化点数§f。
+tooltip.srpcotesia.masticator1=§f喷出有毒的瘴气。瘴气在演化 %d 阶时可侵袭方块，并产生§a进化点数§f。
 tooltip.srpcotesia.masticator2=§f需要§a腥臭“滤毒罐”§f运作。
 tooltip.srpcotesia.masticator3=§4一件由你的记忆和我们自己的记忆共同缔造的艺术品。
 tooltip.srpcotesia.masticator4=§4正如你的直觉所述，最初的设计是有缺陷的。火在此百无一用。
 
 item.srpcotesia.consecrator.name=§4祭献瘴气枪
-tooltip.srpcotesia.consecrator1=§f喷出恐怖的瘴气。如果在§4节点§f范围内，且处于演化 %d 阶时，瘴气可在侵袭方块的同时制造出群系，并增加§a进化点数§f。
+tooltip.srpcotesia.consecrator1=§f喷出恐怖的瘴气。瘴气会侵袭方块，且如果处于演化 %d 阶且在§4节点§f范围内时，将会在这同时制造出寄生体群系，并产生§a进化点数§f。
 tooltip.srpcotesia.consecrator2=§f需要§a腥臭“滤毒罐”§f运作。
 tooltip.srpcotesia.consecrator3=§4从海到海，骨肉相连。
 tooltip.srpcotesia.consecrator4=§4令大地歌唱。
@@ -544,11 +544,11 @@ tooltip.srpcotesia.bounty2=§f所有生成在范围内的§6强化生物§f都�
 tooltip.srpcotesia.bountydisabled=§6悬赏§f目前已被禁用。
 
 message.srpcotesia.bounty.created=§f一个§6悬赏§f已被放置。
-message.srpcotesia.bounty.notify=§f一个§6悬赏§f已进行通报。
+message.srpcotesia.bounty.notify=§f一个§6悬赏§f已被通报。
 
 tile.srpcotesia.osmosis.name=§b渗透活化器
 tooltip.srpcotesia.osmosis1=§f根据放入的§9反应物§f对§9酿造囊§f进行改造。用酿造囊或§9反应物§f右键点击放入。
-tooltip.srpcotesia.osmosis2=§f提示框内会显示被活化后§9反应物§f的效果。  
+tooltip.srpcotesia.osmosis2=§f提示框内会显示被活化后§9反应物§f的效果。
 
 tile.srpcotesia.lithograph.name=§b蚀刻机
 tooltip.srpcotesia.lithograph1=§f从§d遗骸§f提取数据用于生产§6芯片节段§f。手持不同的§d遗骸§f右键点击放入。
@@ -590,7 +590,7 @@ item.srpcotesia.pact.name=§a契约
 tooltip.srpcotesia.pact=§f一份来历不明的寄染卷轴。
 tooltip.srpcotesia.pact1=§f可用于在已加载的区块内§4遣散除§a连结种§4以外所有正在活动中的寄生体§f。在全局演化阶段冷却时该物品无法生效。且该物品也无法对正在维持某些结构的寄生体生效。
 tooltip.srpcotesia.pact2=§f如果对除§e寄生巢穴§f以外的§a连结种§f使用该物品，它也会遣散所有这一阶段或者低于该阶段的§a连结种§f。
-tooltip.srpcotesia.pact3=§f如果对你所创造的寄生体使用该物品，不会自然消失的寄生体也会被遣散。这同样不包括§e寄生巢穴§f，而前述的遣散机制同样会生效。
+tooltip.srpcotesia.pact3=§f如果对你所创造的寄生体使用该物品，不会自然消失的寄生体也会被遣散。这同样不包括§e寄生巢穴§f，而前述的遣散限制同样会生效。
 tooltip.srpcotesia.pact4=§f此后，一份§a循迹腺体§f将会生成，它会记录下你所遣散的最高级别的寄生体（扎根于地面或由你创造的寄生体除外）。潜行可以避免此事发生，过程中物品也不会被消耗。
 tooltip.srpcotesia.pact5=§4证明这一概念的合理性是项艰巨的任务。
 

--- a/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/srp-addon-cotesia-glomerata/srpcotesia/lang/zh_cn.lang
@@ -807,8 +807,8 @@ message.srpcotesia.defense=继续攻击。还剩 %d 防御值。
 message.srpcotesia.nodefense=继续攻击。
 #message.srpcotesia.catchup=The points I'm getting are of no substance, since there's an Evolution Cooldown.
 
-message.srpcotesia.dissolution.possess=它还未成型。
-message.srpcotesia.dissolution.nothing=它尚未生效。
+message.srpcotesia.dissolution.possess=这只与你并不相容。
+message.srpcotesia.dissolution.nothing=这根本行不通。
 message.srpcotesia.dissolution.possessing=它已经为我们腾出了空间。心怀感激吧。
 
 message.srpcotesia.bounty.intervention=有什么东西在跟着你。


### PR DESCRIPTION
对部分指令文本和描述文本也做了小修改。
帕秋莉手册翻译只能说coming soooooooon了
207行的§7变色是因为这个提示栏原色真的是深灰色，用§r还原会一半灰一半白_(:з」∠)_

*防止后续注释编辑抽风，一些更新内容和可能不大确定的翻译也在这贴一下：

- Unkindling（阻燃）：类似抗火效果，但在寄生体身上没有效果。
- Yielding（屈从）：新负面药水效果。持有该效果时，每级将导致每次受生物攻击时，受击伤害会包含相当于当事人最大生命值5%的真实伤害，并缩减10%的受伤无敌帧时长；与此同时，四级及以上效果时，受到的生物伤害将全数变为真实伤害。
- clotting（凝血）：阻止生命恢复（80%概率）。

- possessing（夺舍）：SRPC近期做了Requiem/Dissolution/Tartaros的mod兼容，因此夺舍怪物确实是可行的。

-Mote（微尘）：由悬赏方块释放或者由强化生物留下的粒子，长得很像潜影贝导弹但飞的比它快。命中时通常不会造成伤害，但二者都会在寄生体玩家身后发射mote进行追踪，并在命中玩家后将发射mote/放置上述悬赏的强化生物传送到玩家身边。
——或许有更好的方案吗？或许……

-Consecrator（祭献瘴气枪）：词源consecration（献祭，祝圣），确实是上面那个瘴气枪的plus升级版。

-Defense（防御值）：强化生物持有特性，它们将拥有对寄生体的特殊护盾，相当于额外的生命值。
-Hyperarmor（超能护甲）：强化生物持有特性，在寄生体攻击力低于该值时将不会造成伤害。
——我知道这条lang里面没有，但我想确认一下有没有更好的说法……