### PR TITLE
修正“Warlock”被误译为“狂术士”的错误

### DIFF
--- a/projects/1.12.2/assets/ancient-spellcraft/ancientspellcraft/lang/zh_cn.lang
+++ b/projects/1.12.2/assets/ancient-spellcraft/ancientspellcraft/lang/zh_cn.lang
@@ -79,7 +79,7 @@ item.ancientspellcraft\:crystal_silver_nugget.name=晶银粒
 item.ancientspellcraft\:enchanted_filament.name=附魔细丝
 wizard_armour_class.sage=贤者
 wizard_armour_class.battlemage=战斗法师
-wizard_armour_class.warlock=狂术士
+wizard_armour_class.warlock=巫术士
 
 #entity
 entity.ancientspellcraft\:devoritium_bomb.name=噬法炸弹


### PR DESCRIPTION
巫术学的“巫术士套装”译为“Warlock Suit”，巫术学附属古代咒法有些法术施放需要穿戴此套装，但却被译为需要穿戴“狂术士套装”

<!--
提交PR前请认真阅读下列文件：
贡献方针：https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md

你好！如果你是第一次提交 PR，请阅读下面的话：
请务必做好下面两件事情，一定一定不要提交了就不管了哦（这样会被拒收的哦）：
- 签署 CLA（贡献者许可协议；在 https://cla-assistant.io/CFPAOrg/Minecraft-Mod-Language-Package 签署）
- 等待审核者审核，并根据审核者的提示（邮件会发送）修改你提交的文件（修改方法可以参考 https://cfpa.cyan.cafe/Azusa/img/tip1.png ）
如果你访问 GitHub 较慢或根本无法访问，可以前往 https://cfpa.cyan.cafe/Azusa/GitHubInCNHelper 查看一些辅助访问的手段。
再次非常感谢你的提交。
-->
