### PR TITLE
upload-artifact v3 deprecation

### DIFF
--- a/.github/workflows/pr-packer.yml
+++ b/.github/workflows/pr-packer.yml
@@ -8,6 +8,7 @@ on:
       - 'src/**'
       - 'config/packer/**'
       - 'projects/**'
+      - '.github/workflows/pr-packer.yml'
 
 
 

--- a/.github/workflows/pr-packer.yml
+++ b/.github/workflows/pr-packer.yml
@@ -102,7 +102,7 @@ jobs:
         if: steps.check-changes.outputs.changed == 'true' ||  github.event_name == 'workflow_dispatch'
           
       - name: Upload Artifact for ${{ matrix.version }}
-        uses: actions/upload-artifact@v3.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: Minecraft-Mod-Language-Package-${{ matrix.version }}
           path: Minecraft-Mod-Language-Package-${{ matrix.version }}/*


### PR DESCRIPTION
参见：https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

仅限pr-packer；packer估计是哪次已经更到v4了，就不用更了