### PR TITLE
Bump actions/cache to v4

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -26,7 +26,7 @@ jobs:
       # actions/cache的逻辑会在job末尾缓存打包程序；如果不命中，就自行构造程序。
       - name: Cache Packer
         id: cache-packer
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-Packer-${{ hashFiles('src/Packer/**') }}
           path: |
@@ -53,7 +53,7 @@ jobs:
   #     # actions/cache的逻辑会在job末尾缓存打包程序；如果不命中，就自行构造程序。
   #     - name: Cache Uploader
   #       id: cache-uploader
-  #       uses: actions/cache@v3
+  #       uses: actions/cache@v4
   #       with:
   #         key: ${{ runner.os }}-Uploader-${{ hashFiles('src/Uploader/**') }}
   #         path: Uploader.exe
@@ -109,8 +109,7 @@ jobs:
       # 由于Github的限制，这里需要重新拉取打包程序。
       - name: Restore Packer
         id: cache-restore
-        # https://github.com/actions/cache/issues/1265#issuecomment-1819612829 `fail-on-cache-miss` for restore action not failing the workflow
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-Packer-${{ hashFiles('source/Packer/**') }}
           path: |

--- a/.github/workflows/pr-packer.yml
+++ b/.github/workflows/pr-packer.yml
@@ -28,7 +28,7 @@ jobs:
       # actions/cache的逻辑会在job末尾缓存打包程序；如果不命中，就自行构造程序。
       - name: Cache Packer
         id: cache-packer
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-Packer-${{ hashFiles('src/Packer/**') }}
           path: |
@@ -62,8 +62,7 @@ jobs:
       # 由于Github的限制，这里需要重新拉取打包程序。
       - name: Restore Packer
         id: cache-restore
-        # https://github.com/actions/cache/issues/1265#issuecomment-1819612829 `fail-on-cache-miss` for restore action not failing the workflow
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-Packer-${{ hashFiles('src/Packer/**') }}
           path: |


### PR DESCRIPTION
其实原来用的v3还没弃用，但是Github好像不认为v3.3.1是v3的一部分……
正好v3用的node 16理论上也弃用了，于是一步到位算了