### PR TITLE
Archers 翻译更新

### DIFF
--- a/projects/1.21-fabric/assets/archers/archers/lang/en_us.json
+++ b/projects/1.21-fabric/assets/archers/archers/lang/en_us.json
@@ -1,0 +1,91 @@
+{
+  "itemGroup.archers.general": "Archers",
+  "item.archers.auto_fire_hook.description_1": "Automatically releases charged arrow.",
+  "item.archers.auto_fire_hook.description_2": "Can be applied to ranged weapons, on an Anvil.",
+  "item.ranged_weapon.pull_time": "%1$s sec Pull Time",
+
+  "block.archers.archers_workbench": "Archery Artisan Table",
+  "block.archers.archers_workbench.hint": "Workbench for Archery Artisan Villagers.",
+  "entity.minecraft.villager.archery_artisan": "Archery Artisan",
+  "entity.minecraft.villager.archers:archery_artisan": "Archery Artisan",
+
+  "item.archers.auto_fire_hook": "Auto-Fire Hook",
+  "item.archers.small_quiver": "Quiver",
+  "item.archers.medium_quiver": "Hunting Quiver",
+  "item.archers.large_quiver": "Battle Quiver",
+  "item.archers.quiver.hint": "Provides arrows for archery, when equipped.",
+
+  "item.archers.flint_spear": "Flint Spear",
+  "item.archers.iron_spear": "Iron Spear",
+  "item.archers.golden_spear": "Golden Spear",
+  "item.archers.diamond_spear": "Diamond Spear",
+  "item.archers.netherite_spear": "Netherite Spear",
+  "item.archers.aeternium_spear": "Aeternium Spear",
+  "item.archers.ruby_spear": "Ruby Spear",
+  "item.archers.aether_spear": "Holy Spear",
+
+  "item.archers.archer_armor_head": "Archer Hood",
+  "item.archers.archer_armor_chest": "Archer Tunic",
+  "item.archers.archer_armor_legs": "Archer Leggings",
+  "item.archers.archer_armor_feet": "Archer Boots",
+
+  "item.archers.ranger_armor_head": "Ranger Hood",
+  "item.archers.ranger_armor_chest": "Ranger Tunic",
+  "item.archers.ranger_armor_legs": "Ranger Leggings",
+  "item.archers.ranger_armor_feet": "Ranger Boots",
+
+  "item.archers.netherite_ranger_armor_head": "Netherite Ranger Hood",
+  "item.archers.netherite_ranger_armor_chest": "Netherite Ranger Tunic",
+  "item.archers.netherite_ranger_armor_legs": "Netherite Ranger Leggings",
+  "item.archers.netherite_ranger_armor_feet": "Netherite Ranger Boots",
+
+  "item.archers.composite_longbow": "Composite Longbow",
+  "item.archers.mechanic_shortbow": "Mechanical Shortbow",
+  "item.archers.royal_longbow": "Royal Longbow",
+  "item.archers.rapid_crossbow": "Rapid Crossbow",
+  "item.archers.heavy_crossbow": "Heavy Crossbow",
+  "item.archers.netherite_shortbow": "Netherite Shortbow",
+  "item.archers.netherite_longbow": "Netherite Longbow",
+  "item.archers.netherite_rapid_crossbow": "Netherite Rapid Crossbow",
+  "item.archers.netherite_heavy_crossbow": "Netherite Heavy Crossbow",
+  "item.archers.crystal_shortbow": "Crystal Shortbow",
+  "item.archers.crystal_longbow": "Crystal Longbow",
+  "item.archers.ruby_rapid_crossbow": "Ruby Rapid Crossbow",
+  "item.archers.ruby_heavy_crossbow": "Ruby Heavy Crossbow",
+  "item.archers.aether_longbow": "Silver Bow of the Acropolis",
+  "item.archers.aether_rapid_crossbow": "Sky Crossbow",
+  "item.archers.aether_heavy_crossbow": "Valkyrie Ballista",
+
+  "item.archers.archer_spell_book": "Archery Manual",
+  "item.archers.archer.spell_scroll": "Archery Scroll",
+
+  "spell.archers.power_shot.name": "Power Shot",
+  "spell.archers.power_shot.description": "Your next {effect_amplifier} arrows inflict the target with Hunter's Mark for {effect_duration} seconds, increasing its damage taken by {damage_taken}, stacking up to {effect_amplifier} times.",
+  "effect.archers.hunters_mark_stash": "Power Shot",
+  "effect.archers.hunters_mark_stash.description": "Next shot applies Hunter's Mark",
+  "effect.archers.hunters_mark": "Marked",
+  "effect.archers.hunters_mark.description": "Increases damage taken from all sources",
+
+  "spell.archers.entangling_roots.name": "Entangling Roots",
+  "spell.archers.entangling_roots.description": "Conjures roots to sprout from the ground in the nearby area, slowing down enemies for {cloud_duration} seconds.",
+  "effect.archers.entangling_roots": "Entangling Roots",
+  "effect.archers.entangling_roots.description": "Reduces movement speed",
+
+  "spell.archers.barrage.name": "Barrage",
+  "spell.archers.barrage.description": "Fires multiple arrows in quick succession.",
+
+  "spell.archers.magic_arrow.name": "Magic Arrow",
+  "spell.archers.magic_arrow.description": "Shoots a magical arrow piercing thru all enemies in its path, dealing {damage} damage to each target.",
+
+  "advancements.rpg_series.path_choose_archer.title": "Path of Archery",
+  "advancements.rpg_series.path_choose_archer.description": "Create as Archery Manual",
+
+  "advancements.rpg_series.spell_novice_archer.title": "Lethal Shots",
+  "advancements.rpg_series.spell_novice_archer.description": "Obtain your first Archery skill",
+
+  "advancements.rpg_series.spell_master_archer.title": "Ballistics Expert",
+  "advancements.rpg_series.spell_master_archer.description": "Complete the full Archery Manual",
+
+  "advancements.rpg_series.obtain_arrow.title": "Path of Archer",
+  "advancements.rpg_series.obtain_arrow.description": "Obtain an Arrow"
+}

--- a/projects/1.21-fabric/assets/archers/archers/lang/zh_cn.json
+++ b/projects/1.21-fabric/assets/archers/archers/lang/zh_cn.json
@@ -1,0 +1,91 @@
+{
+  "itemGroup.archers.general":"弓箭手",
+  "item.archers.auto_fire_hook.description_1":"自动发射上弦的箭。",
+  "item.archers.auto_fire_hook.description_2":"在铁砧上可附加于远程武器。",
+  "item.ranged_weapon.pull_time":"%1$s秒 拉弦时间",
+
+  "block.archers.archers_workbench":"弓匠台",
+  "block.archers.archers_workbench.hint":"弓匠村民的工作台",
+  "entity.minecraft.villager.archery_artisan":"弓匠",
+  "entity.minecraft.villager.archers:archery_artisan":"弓匠",
+
+  "item.archers.auto_fire_hook": "自动发射钩",
+  "item.archers.small_quiver": "箭袋",
+  "item.archers.medium_quiver": "狩猎箭袋",
+  "item.archers.large_quiver": "战斗箭袋",
+  "item.archers.quiver.hint": "当装备时，为弓箭手提供箭矢。",
+
+  "item.archers.flint_spear":"燧石长枪",
+  "item.archers.iron_spear":"铁长枪",
+  "item.archers.golden_spear":"金长枪",
+  "item.archers.diamond_spear":"钻石长枪",
+  "item.archers.netherite_spear":"下界合金长枪",
+  "item.archers.aeternium_spear":"太古合金长枪",
+  "item.archers.ruby_spear":"红宝石长枪",
+  "item.archers.aether_spear":"神圣长枪",
+
+  "item.archers.archer_armor_head":"射手兜帽",
+  "item.archers.archer_armor_chest":"射手外衣",
+  "item.archers.archer_armor_legs":"射手护腿",
+  "item.archers.archer_armor_feet":"射手靴子",
+
+  "item.archers.ranger_armor_head":"游侠兜帽",
+  "item.archers.ranger_armor_chest":"游侠外衣",
+  "item.archers.ranger_armor_legs":"游侠护腿",
+  "item.archers.ranger_armor_feet":"游侠靴子",
+
+  "item.archers.netherite_ranger_armor_head":"下界合金游侠兜帽",
+  "item.archers.netherite_ranger_armor_chest":"下界合金游侠外衣",
+  "item.archers.netherite_ranger_armor_legs":"下界合金游侠护腿",
+  "item.archers.netherite_ranger_armor_feet":"下界合金游侠靴子",
+
+  "item.archers.composite_longbow":"复合长弓",
+  "item.archers.mechanic_shortbow":"机械短弓",
+  "item.archers.royal_longbow":"皇家长弓",
+  "item.archers.rapid_crossbow":"轻型弩",
+  "item.archers.heavy_crossbow":"重型弩",
+  "item.archers.netherite_shortbow":"下界合金短弓",
+  "item.archers.netherite_longbow":"下界合金长弓",
+  "item.archers.netherite_rapid_crossbow":"下界合金轻型弩",
+  "item.archers.netherite_heavy_crossbow":"下界合金重型弩",
+  "item.archers.crystal_shortbow":"紫水晶短弓",
+  "item.archers.crystal_longbow":"紫水晶长弓",
+  "item.archers.ruby_rapid_crossbow":"红宝石轻型弩",
+  "item.archers.ruby_heavy_crossbow":"红宝石重型弩",
+  "item.archers.aether_longbow":"卫城银弓",
+  "item.archers.aether_rapid_crossbow":"天空弩",
+  "item.archers.aether_heavy_crossbow":"瓦尔基里弩车",
+
+  "item.archers.archer_spell_book":"弓术手册",
+  "item.archers.archer.spell_scroll":"弓箭卷轴",
+
+  "spell.archers.power_shot.name":"强力射击",
+  "spell.archers.power_shot.description":"你接下来{effect_amplifier}支箭会对目标施加猎人印记，持续{effect_duration}秒，使其受到的所有伤害提高{damage_taken}，该效果最多可叠加{effect_amplifier}次。",
+  "effect.archers.marker_shot":"强力射击",
+  "effect.archers.marker_shot.description":"将猎人印记附着在下一次射击上",
+  "effect.archers.hunters_mark":"印记",
+  "effect.archers.hunters_mark.description":"所有受到的伤害增加",
+
+  "spell.archers.entangling_roots.name":"纠缠根须",
+  "spell.archers.entangling_roots.description":"召唤根须破土而出，缠绕附近范围的敌人，使其减速，持续{cloud_duration}秒。",
+  "effect.archers.entangling_roots":"纠缠之根",
+  "effect.archers.entangling_roots.description":"减缓移动速度",
+
+  "spell.archers.barrage.name":"弹幕",
+  "spell.archers.barrage.description":"快速地连续发射多支箭矢",
+
+  "spell.archers.magic_arrow.name":"魔法箭矢",
+  "spell.archers.magic_arrow.description":"射出一支魔法箭矢，穿刺路径上的所有敌人，对每个目标造成{damage}点伤害。",
+
+  "advancements.rpg_series.path_choose_archer.title":"弓箭手之路",
+  "advancements.rpg_series.path_choose_archer.description":"合成一本弓术手册",
+
+  "advancements.rpg_series.spell_novice_archer.title":"夺命射击",
+  "advancements.rpg_series.spell_novice_archer.description":"获得你的第一个弓术技巧",
+
+  "advancements.rpg_series.spell_master_archer.title":"弹道学专家",
+  "advancements.rpg_series.spell_master_archer.description":"完成整本弓术手册",
+
+  "advancements.rpg_series.obtain_arrow.title":"弓箭手之道",
+  "advancements.rpg_series.obtain_arrow.description":"获得一个矢"
+}


### PR DESCRIPTION
RPG Series系列之一，主要内容是加入了弓箭手职业，里面的技能主要是取自于魔兽世界猎人的射击分支。

Line89的进度，不知道为什么在游戏里面找不到对应内容了，进度翻译的内容也拿不准，采用了直译。

翻译主要参考了库中的旧翻译，与魔兽世界相关内容。

#机器人校验补，模组似乎更新了，等我自己再重新弄一下吧。