### PR TITLE
feat: 时机不对时取消上传

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -178,5 +178,10 @@ jobs:
         with:
           path: artifacts/
 
+      # feat: UTC 20:00~21:00 取消上传（避开远程服务器的4:00-4:10）
+      - name: Fail at inappropriate time
+        run: if [ `date -u +%H` -eq 20 ]; then exit -1; fi
+        shell: bash
+
       - name: Run Uploader
         run: .\Uploader --host="${{ secrets.SSH_IP }}" --name="${{ secrets.SSH_USER }}" --password="${{ secrets.SSH_PWD }}"


### PR DESCRIPTION
per 葫芦：4:00-4:10（应该是UTC+8）远程服务器在同步，需要避免上传
这里的方法是，在上传前如果到点了直接fail掉（
（虽然这个时间不太会有人合并，但并不是不可能）