### PR TITLE
Update PlayerRevive zh_cn.json

### DIFF
--- a/projects/1.20/assets/playerrevive/playerrevive/lang/zh_cn.json
+++ b/projects/1.20/assets/playerrevive/playerrevive/lang/zh_cn.json
@@ -1,8 +1,9 @@
 {
-	"playerrevive.chat.bleeding": "%s伤重垂危……%s",
-	"death.attack.bledToDeath.player": "%s流血致死",
-	"playerrevive.gui.button.send": "发送",
-	"playerrevive.gui.label.time_left": "剩余时间：%s",
-	"playerrevive.gui.hold": "等待救援或按住“%s”%s秒放弃挣扎",
-	"playerrevive.revive.item": "你需要"
+  "playerrevive.chat.bleeding": "%s重伤倒地⋯⋯",
+  "death.attack.bledToDeath.player": "%s流血致死",
+  "playerrevive.gui.button.send": "发送",
+  "playerrevive.gui.label.time_left": "剩余时间：%s",
+  "playerrevive.gui.hold": "等待救援或按住“%s”%s秒放弃挣扎",
+  "playerrevive.revive.item": "你需要%s",
+  "playerrevive.chat.no_commands":  "流血状态下无法使用指令" 
 }


### PR DESCRIPTION
修正玩家救援MOD原本的汉化错误，并翻译2.0.31版本模组增加的内容
经过测试这个翻译文件没有问题（原来的版本因为多加了个%s无法显示倒地玩家名）

<!--
提交PR前请认真阅读下列文件：
贡献方针：https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md

你好！如果你是第一次提交 PR，请阅读下面的话：
请务必做好下面两件事情，一定一定不要提交了就不管了哦（这样会被拒收的哦）：
- 签署 CLA（贡献者许可协议；在 https://cla-assistant.io/CFPAOrg/Minecraft-Mod-Language-Package 签署）
- 等待审核者审核，并根据审核者的提示（邮件会发送）修改你提交的文件（修改方法可以参考 https://cfpa.cyan.cafe/Azusa/img/tip1.png ）
如果你访问 GitHub 较慢或根本无法访问，可以前往 https://cfpa.cyan.cafe/Azusa/GitHubInCNHelper 查看一些辅助访问的手段。
再次非常感谢你的提交。
-->
