### PR TITLE
ExtendedAE 手册修复

### DIFF
--- a/projects/1.21/assets/ex-pattern-provider/extendedae/ae2guide/_zh_cn/epp_intro/active_formation_plane.md
+++ b/projects/1.21/assets/ex-pattern-provider/extendedae/ae2guide/_zh_cn/epp_intro/active_formation_plane.md
@@ -15,6 +15,6 @@ item_ids:
   <ImportStructure src="../structure/cable_active_formation_plane.snbt"></ImportStructure>
 </GameScene>
 
-ME主动成型面板的性质与<ItemLink id="ae2:formation_plane" >相同，但可以主动放置方块和丢出物品。
+ME主动成型面板的性质与<ItemLink id="ae2:formation_plane" />相同，但可以主动放置方块和丢出物品。
 
 无需为其设置子网络。它相当于不会输出至箱子、而是会放置方块的<ItemLink id="ae2:export_bus" />。


### PR DESCRIPTION
<!--
提交PR前请认真阅读下列文件：
贡献方针：https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md

你好！如果你是第一次提交 PR，请阅读下面的话：
请务必做好下面两件事情，一定一定不要提交了就不管了哦（这样会被拒收的哦）：
- 签署 CLA（贡献者许可协议；在 https://cla-assistant.io/CFPAOrg/Minecraft-Mod-Language-Package 签署）
- 等待审核者审核，并根据审核者的提示（邮件会发送）修改你提交的文件（修改方法可以参考 https://cfpa.cyan.cafe/Azusa/img/tip1.png ）
如果你访问 GitHub 较慢或根本无法访问，可以前往 https://cfpa.cyan.cafe/Azusa/GitHubInCNHelper 查看一些辅助访问的手段。
再次非常感谢你的提交。
-->
GuideME里的自定义标签必须闭合，不然对应页面不会加载
从目前的版本来看，出现此类问题时不会默认加载某语言的文件，而是页面直接消失，查看对应物品指南的操作也会被禁用

已在游戏内测试过，改完就可以正常显示了

话说撞的PR怎么处理（