### PR TITLE
Macro Keybinds  翻译提交

### DIFF
--- a/projects/1.21/assets/macrokeybinds/macrokeybinds/lang/en_us.json
+++ b/projects/1.21/assets/macrokeybinds/macrokeybinds/lang/en_us.json
@@ -1,0 +1,55 @@
+{
+  "text.config.mainscreen": "Keybinds Menu",
+  "text.config.globalmacros": "Global Macros Options",
+  "text.config.servermacros": "Server Macros Options",
+  "text.config.needhelp": "Need Help? Bug? Discord Link",
+  "text.tooltip.main.noserver": "You are not on a server",
+
+  "key.macrokeybinds.openoptions.desc": "Open Gui Option" ,
+  "key.categories.macrokeybinds": "MacroKeybinds",
+
+  "text.globalmacros.title": "Global Macros",
+  "text.createglobalmacros.title": "Create New Global Macro",
+  "text.globalmacros.back": "Cancel",
+
+  "text.servermacros.title": "Server Macros",
+  "text.createservermacros.title": "Create New Server Macro",
+  "text.servermacros.back": "Cancel",
+
+  "text.createmacro": "Create Macro",
+  "text.editmacro": "Edit Macro",
+
+  "text.type.simple": "Simple",
+  "text.type.toggle": "Toggle",
+  "text.type.repeat": "Repeat",
+  "text.type.delayed": "Delayed",
+  "text.key": "Key",
+
+  "text.action.message": "Send Message",
+  "text.action.command": "Execute Command",
+  "text.action.fillchat": "Fill Chat Without Send",
+
+  "text.tooltip.namebox": "Name",
+  "text.tooltip.actionbox": "Action",
+  "text.tooltip.timebox": "Cooldown/Delay between execution",
+  "text.tooltip.timeboxsub": "(in millisecond)",
+  "text.tooltip.macrotype": "Select between 4 types of macro.",
+  "text.tooltip.actiontype": "Select between 3 types of action.",
+  "text.tooltip.keybind": "Click and press the wanted key",
+  "text.tooltip.editmacro.state": "Disable/Enable Macro",
+  "text.tooltip.editmacro.edit": "Edit Macro",
+  "text.tooltip.editmacro.delete": "Delete Macro",
+  "text.tooltip.editmacro.forgotvalue": "You forgot to complete one or more fields",
+  "text.tooltip.editmacro.keyalreadyassigned": "This key is already assigned ! (However you can assign it)",
+  "text.macro.deleteQuestion": "Are you sure you want to delete this macro?",
+  "text.macro.deleteWarning": "It will be deleted permanently",
+  "text.macro.deleteButton": "Delete this macro",
+
+  "text.running": "R",
+  "text.tooltip.running": "Running",
+  "text.stopmacro": "Stop All Delayed/Repeat macros",
+
+  "text.editglobalmacro.title": "Edit Global Macro",
+  "text.editservermacro.title": "Edit Server Macro"
+
+}

--- a/projects/1.21/assets/macrokeybinds/macrokeybinds/lang/zh_cn.json
+++ b/projects/1.21/assets/macrokeybinds/macrokeybinds/lang/zh_cn.json
@@ -1,0 +1,54 @@
+{
+  "text.config.mainscreen": "按键绑定菜单",
+  "text.config.globalmacros": "全局宏选项",
+  "text.config.servermacros": "服务器宏选项",
+  "text.config.needhelp": "需要帮助？Bug？Discord链接",
+  "text.tooltip.main.noserver": "你未连接服务器",
+
+  "key.macrokeybinds.openoptions.desc": "打开选项GUI" ,
+  "key.categories.macrokeybinds": "宏键位绑定（Macro Keybinds）",
+
+  "text.globalmacros.title": "全局宏",
+  "text.createglobalmacros.title": "新建全局宏",
+  "text.globalmacros.back": "取消",
+
+  "text.servermacros.title": "服务器宏",
+  "text.createservermacros.title": "新建服务器宏",
+  "text.servermacros.back": "取消",
+
+  "text.createmacro": "新建宏",
+  "text.editmacro": "编辑宏",
+
+  "text.type.simple": "简易",
+  "text.type.toggle": "切换",
+  "text.type.repeat": "重复",
+  "text.type.delayed": "延迟",
+  "text.key": "按键",
+
+  "text.action.message": "发送信息",
+  "text.action.command": "执行命令",
+  "text.action.fillchat": "填入聊天栏但不发送",
+
+  "text.tooltip.namebox": "名称",
+  "text.tooltip.actionbox": "行为",
+  "text.tooltip.timebox": "运行之间的冷却/延迟",
+  "text.tooltip.timeboxsub": "（以毫秒计）",
+  "text.tooltip.macrotype": "在四种宏模式间选择。",
+  "text.tooltip.actiontype": "在三种行为间选择。",
+  "text.tooltip.keybind": "点击后按下期望按键",
+  "text.tooltip.editmacro.state": "禁用/启用宏",
+  "text.tooltip.editmacro.edit": "编辑宏",
+  "text.tooltip.editmacro.delete": "删除宏",
+  "text.tooltip.editmacro.forgotvalue": "你有字段尚未填写完整",
+  "text.tooltip.editmacro.keyalreadyassigned": "该按键已被占用！（仍可再次分配）",
+  "text.macro.deleteQuestion": "您确定要删除此宏吗？",
+  "text.macro.deleteWarning": "它将被永久删除",
+  "text.macro.deleteButton": "删除此宏",
+
+  "text.running": "运",
+  "text.tooltip.running": "运行中",
+  "text.stopmacro": "停止所有延迟/重复宏",
+
+  "text.editglobalmacro.title": "编辑全局宏",
+  "text.editservermacro.title": "编辑服务器宏"
+}

--- a/projects/1.21/assets/macrokeybinds/macrokeybinds/lang/zh_cn.json
+++ b/projects/1.21/assets/macrokeybinds/macrokeybinds/lang/zh_cn.json
@@ -31,7 +31,7 @@
 
   "text.tooltip.namebox": "名称",
   "text.tooltip.actionbox": "行为",
-  "text.tooltip.timebox": "运行之间的冷却/延迟",
+  "text.tooltip.timebox": "动作间的冷却/延迟",
   "text.tooltip.timeboxsub": "（以毫秒计）",
   "text.tooltip.macrotype": "在四种宏模式间选择。",
   "text.tooltip.actiontype": "在三种行为间选择。",


### PR DESCRIPTION
Added en_us.json and zh_cn.json language files for MacroKeybinds, providing English and Simplified Chinese translations for UI elements and tooltips.

关于 Toggle 和 Repeat 可能存在的问题，见 https://github.com/Thomas7520/MacroKeybinds/issues/4

<!--
提交PR前请认真阅读下列文件：
贡献方针：https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md

你好！如果你是第一次提交 PR，请阅读下面的话：
请务必做好下面两件事情，一定一定不要提交了就不管了哦（这样会被拒收的哦）：
- 签署 CLA（贡献者许可协议；在 https://cla-assistant.io/CFPAOrg/Minecraft-Mod-Language-Package 签署）
- 等待审核者审核，并根据审核者的提示（邮件会发送）修改你提交的文件（修改方法可以参考 https://cfpa.cyan.cafe/Azusa/img/tip1.png ）
如果你访问 GitHub 较慢或根本无法访问，可以前往 https://cfpa.cyan.cafe/Azusa/GitHubInCNHelper 查看一些辅助访问的手段。
再次非常感谢你的提交。
-->
