### PR TITLE
新增 GuideME Label 相关内容

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -44,6 +44,9 @@ labelPRBasedOnFilePath:
     Patchouli:
         - "projects/**/patchouli_books/**"
 
+    GuideME:
+        - "projects/**/assets/**/**/guides/**"
+
     source:
         - "src/**"
 


### PR DESCRIPTION
貌似是这么改的吧，我已经忘掉了

<!--
提交PR前请认真阅读下列文件：
贡献方针：https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md

你好！如果你是第一次提交 PR，请阅读下面的话：
请务必做好下面两件事情，一定一定不要提交了就不管了哦（这样会被拒收的哦）：
- 签署 CLA（贡献者许可协议；在 https://cla-assistant.io/CFPAOrg/Minecraft-Mod-Language-Package 签署）
- 等待审核者审核，并根据审核者的提示（邮件会发送）修改你提交的文件（修改方法可以参考 https://cfpa.cyan.cafe/Azusa/img/tip1.png ）
如果你访问 GitHub 较慢或根本无法访问，可以前往 https://cfpa.cyan.cafe/Azusa/GitHubInCNHelper 查看一些辅助访问的手段。
再次非常感谢你的提交。
-->

近期很多模组开始从 Patchouli 转 GuideME 了，再加上 AE2 系列模组的手册也全是 GuideME，确实有必要单开一个 Label 标注一下

考虑中的问题：是否需要将 `Patchouli` 与 `GuideME` 标签合并为 `Guide` 或 `指导书` 标签，这样更为直接了当。