### PR TITLE
Occultism 1.20版本停止支持

### DIFF
--- a/config/packer/1.20.json
+++ b/config/packer/1.20.json
@@ -8,7 +8,8 @@
         "exclusionNamespaces": [
             "cataclysm",
             "alexscaves",
-            "biomancy"
+            "biomancy",
+            "occultism"
         ]
     },
     "floating": {


### PR DESCRIPTION
1.18版本的翻译会覆盖1.20自带的汉化文本