### PR TITLE
更新标签器配置以支持新路径结构

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -14,7 +14,7 @@ labelPRBasedOnFilePath:
     
     1.19.x:
         - "projects/assets/**/1.19/**"
-        - "projects/assets/**/1.19-fabric/**"
+        # - "projects/assets/**/1.19-fabric/**"
 
     1.20.x:
         - "projects/assets/**/1.20/**"

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -2,83 +2,85 @@
 # Enable "labeler" for your PR that would add labels to PRs based on the paths that are modified in the PR.
 labelPRBasedOnFilePath:
     1.12.x:
-        - "projects/1.12.2/**"
+        - "projects/assets/**/1.12.2/**"
 
     1.16.x:
-        - "projects/1.16/**"
-        - "projects/1.16-fabric/**"
+        - "projects/assets/**/1.16/**"
+        - "projects/assets/**/1.16-fabric/**"
         
     1.18.x:
-        - "projects/1.18/**"
-        - "projects/1.18-fabric/**"
+        - "projects/assets/**/1.18/**"
+        - "projects/assets/**/1.18-fabric/**"
     
     1.19.x:
-        - "projects/1.19/**"
-      # - "projects/1.19-fabric/**"
+        - "projects/assets/**/1.19/**"
+        - "projects/assets/**/1.19-fabric/**"
 
     1.20.x:
-        - "projects/1.20/**"
-        - "projects/1.20-fabric/**"
+        - "projects/assets/**/1.20/**"
+        - "projects/assets/**/1.20-fabric/**"
 
     1.21.x:
-        - "projects/1.21/**"
-        - "projects/1.21-fabric/**"
+        - "projects/assets/**/1.21/**"
+        - "projects/assets/**/1.21-fabric/**"
+
+    26.1.x:
+        - "projects/assets/**/26.1/**"
+        - "projects/assets/**/26.1-fabric/**"
+        
     
     Forge:
-        - "projects/1.12.2/**"
-        - "projects/1.16/**"
-        - "projects/1.18/**"
-        - "projects/1.19/**"
+        - "projects/assets/**/1.12.2/**"
+        - "projects/assets/**/1.16/**"
+        - "projects/assets/**/1.18/**"
+        - "projects/assets/**/1.19/**"
 
     (Neo)Forge:
-        - "projects/1.20/**"
-        - "projects/1.21/**"
+        - "projects/assets/**/1.20/**"
+        - "projects/assets/**/1.21/**"
+        - "projects/assets/**/26.1/**"
     
     Fabric:
-        - "projects/1.16-fabric/**"
-        - "projects/1.18-fabric/**"
-      # - "projects/1.19-fabric/**"
-        - "projects/1.20-fabric/**"
-        - "projects/1.21-fabric/**"
+        - "projects/assets/**/*-fabric/**"
       
     Patchouli:
-        - "projects/**/patchouli_books/**"
+        - "projects/assets/**/patchouli_books/**"
 
     GuideME:
-        - "projects/**/guides/**"
-        - "projects/**/ae2guide/**"
+        - "projects/assets/**/guides/**"
+        - "projects/assets/**/ae2guide/**"
 
     source:
         - "src/**"
 
 # 小语种
     德语:
-        - "projects/assets/**/**/**/lang/de_*.*"
-        - "projects/assets/**/**/**/lang/*_de.*"
-        - "projects/assets/**/**/**/lang/sxu.*"
+        - "projects/assets/**/lang/de_*.*"
+        - "projects/assets/**/lang/*_de.*"
+        - "projects/assets/**/lang/sxu.*"
     意大利语:
-        - "projects/assets/**/**/**/lang/it_*.*"
-        - "projects/assets/**/**/**/lang/*_it.*"
+        - "projects/assets/**/lang/it_*.*"
+        - "projects/assets/**/lang/*_it.*"
     韩语:
-        - "projects/assets/**/**/**/lang/ko_kr.*"
+        - "projects/assets/**/lang/ko_kr.*"
     日语:
-        - "projects/assets/**/**/**/lang/ja_jp.*"
+        - "projects/assets/**/lang/ja_jp.*"
     西班牙语:
-        - "projects/assets/**/**/**/lang/es_*.*"
-        - "projects/assets/**/**/**/lang/*_es.*"
+        - "projects/assets/**/lang/es_*.*"
+        - "projects/assets/**/lang/*_es.*"
     法语:
-        - "projects/assets/**/**/**/lang/fr_*.*"
-        - "projects/assets/**/**/**/lang/*_fr.*"
+        - "projects/assets/**/lang/fr_*.*"
+        - "projects/assets/**/lang/*_fr.*"
     俄语:
-        - "projects/assets/**/**/**/lang/ru_*.*"
-        - "projects/assets/**/**/**/lang/*_ru.*"
-        - "projects/assets/**/**/**/lang/rpr.*"
+        - "projects/assets/**/lang/ru_*.*"
+        - "projects/assets/**/lang/*_ru.*"
+        - "projects/assets/**/lang/rpr.*"
     阿拉伯语:
-        - "projects/assets/**/**/**/lang/ar_sa.*"
+        - "projects/assets/**/lang/ar_sa.*"
     保加利亚语:
-        - "projects/assets/**/**/**/lang/bg_bg.*"
+        - "projects/assets/**/lang/bg_bg.*"
     葡萄牙语:
-        - "projects/assets/**/**/**/lang/pt_*.*"
+        - "projects/assets/**/lang/pt_*.*"
 
 
 # Various Flags to control behaviour of the "Labeler"


### PR DESCRIPTION
### 本 PR 做了什么？

cyborg 采用 [ignore](https://www.npmjs.com/package/ignore) 包，`**` 适配任意层目录，故无需写多层。
简化了fabric标签的匹配。
添加了26.1相关的标签。

### 测试

没做，不会。
