### PR TITLE
Packer 修复模组排除名单

### DIFF
--- a/src/Packer/Program.cs
+++ b/src/Packer/Program.cs
@@ -36,6 +36,7 @@ namespace Packer
                 let modIdentifier = modDirectory.Name
                 where targetModIdentifiers.Count() == 0                             // 未提供列表，全部打包
                     || targetModIdentifiers.Contains(modIdentifier)                 // 有列表，仅打包列表中的项
+                where !config.Base.ExclusionMods.Contains(modIdentifier)            // 没有被明确排除
                 // .../<version>
                 let versionedDirectory = modDirectory.GetDirectories(config.Base.Version).FirstOrDefault(defaultValue: null)
                 where versionedDirectory is not null


### PR DESCRIPTION
问就是，不知道怎么回事写掉了
这块大Linq后续应该会趁着跟i18nmod分功能的时候顺手清理一下，但现在先这样吧
<!--
提交PR前请认真阅读下列文件：
贡献方针：https://github.com/CFPAOrg/Minecraft-Mod-Language-Package/blob/main/CONTRIBUTING.md

你好！如果你是第一次提交 PR，请阅读下面的话：
请务必做好下面两件事情，一定一定不要提交了就不管了哦（这样会被拒收的哦）：
- 签署 CLA（贡献者许可协议；在 https://cla-assistant.io/CFPAOrg/Minecraft-Mod-Language-Package 签署）
- 等待审核者审核，并根据审核者的提示（邮件会发送）修改你提交的文件（修改方法可以参考 https://cfpa.cyan.cafe/Azusa/img/tip1.png ）
如果你访问 GitHub 较慢或根本无法访问，可以前往 https://cfpa.cyan.cafe/Azusa/GitHubInCNHelper 查看一些辅助访问的手段。
再次非常感谢你的提交。
-->
